### PR TITLE
Fix file paths for scripts/ and skills/ directory restructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ All inter-agent communication uses Redis:
 
 ## Agent 1: Screener
 
-**File**: `screener.py`
+**File**: `skills/screener/screener.py`
 **Skill**: `skills/screener/SKILL.md`
 **LLM usage**: ~3–5 calls/day (news evaluation only)
 
@@ -89,7 +89,7 @@ Scan the active instrument universe for RSI-2 entry conditions and detect market
 
 ## Agent 2: Watcher
 
-**File**: `watcher.py`
+**File**: `skills/watcher/watcher.py`
 **Skill**: `skills/watcher/SKILL.md`
 **LLM usage**: ~2 calls/day (news materiality only)
 
@@ -128,7 +128,7 @@ Generate RSI-2 entry and exit signals based on the watchlist and open positions.
 
 ## Agent 3: Portfolio Manager
 
-**File**: `portfolio_manager.py`
+**File**: `skills/portfolio_manager/portfolio_manager.py`
 **Skill**: `skills/portfolio_manager/SKILL.md`
 **LLM usage**: ~3–5 calls/day (GPT-OSS 120B), ~2 calls/week (Claude Sonnet 4 escalation)
 
@@ -184,7 +184,7 @@ If all 3 position slots are full and a Tier 1 signal arrives, the PM may close t
 
 ## Agent 4: Trade Executor
 
-**File**: `executor.py`
+**File**: `skills/executor/executor.py`
 **Skill**: `skills/executor/SKILL.md`
 **LLM usage**: Zero. Pure deterministic code.
 
@@ -228,7 +228,7 @@ Runs automatically before any trading begins:
 
 ## Agent 5: Supervisor
 
-**File**: `supervisor.py`
+**File**: `skills/supervisor/supervisor.py`
 **Skill**: `skills/supervisor/SKILL.md`
 **LLM usage**: ~8–10 calls/week
 
@@ -279,7 +279,7 @@ Deterministic, code-enforced, no LLM involvement:
 | Capital constraint warning | End of day |
 
 ### Monthly Job 1: Universe Re-Validation (1st of month)
-Re-runs `backtest_rsi2_universe.py` on all instruments (active, disabled, and previously failed) using rolling 12-month data. Applies tier thresholds:
+Re-runs `scripts/backtest_rsi2_universe.py` on all instruments (active, disabled, and previously failed) using rolling 12-month data. Applies tier thresholds:
 
 | Tier | Profit Factor | Win Rate | Min Trades |
 |------|--------------|----------|------------|
@@ -290,7 +290,7 @@ Re-runs `backtest_rsi2_universe.py` on all instruments (active, disabled, and pr
 Promotion: max one tier up per month. Demotion: can fall multiple tiers. Disabled for 3+ months → archived.
 
 ### Monthly Job 2: Universe Discovery (15th of month)
-Runs `discover_universe.py` to scan random samples from Alpaca's 12,000+ tradeable assets. Stricter filters than re-validation: ≥ 10 trades, avg trade > 0.30%, WR ≥ 65%, PF ≥ 1.5. Excludes leveraged/inverse ETFs, bond ETFs with tiny moves, and SPACs. New passes enter as Tier 3 (probation), capped at 5 additions per month. Checks sector diversification before adding.
+Runs `scripts/discover_universe.py` to scan random samples from Alpaca's 12,000+ tradeable assets. Stricter filters than re-validation: ≥ 10 trades, avg trade > 0.30%, WR ≥ 65%, PF ≥ 1.5. Excludes leveraged/inverse ETFs, bond ETFs with tiny moves, and SPACs. New passes enter as Tier 3 (probation), capped at 5 additions per month. Checks sector diversification before adding.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ chmod 600 ~/.trading_env
 
 # 5. Verify infrastructure
 source ~/.trading_env
-python3 verify_alpaca.py
+python3 scripts/verify_alpaca.py
 
 # 6. Link skills to OpenClaw workspace
 ln -s ~/trading-system/skills <your-openclaw-workspace>/skills/trading
@@ -100,7 +100,7 @@ Redis runs on port 6379, TimescaleDB on port 5432. The database schema is automa
 5. Visit `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates` in a browser
 6. Find your `chat_id` in the JSON response
 7. Add both to `~/.trading_env`
-8. Test: `python3 notify.py`
+8. Test: `python3 scripts/notify.py`
 
 The system sends: trade entry/exit alerts (immediate), daily summaries (4:15 PM ET), weekly summaries (Saturday morning), monthly summaries (1st of month), drawdown alerts, and critical system alerts. If Telegram is not configured, notifications print to console logs instead.
 
@@ -141,41 +141,43 @@ Logs rotate automatically — files older than 7 days are deleted on startup.
 
 ### Manual Commands
 
+Run from the repo root (`~/trading-system`) after `source ~/.trading_env`.
+
 ```bash
 # Run a single screener scan (no daemon)
-python3 screener.py
+PYTHONPATH=scripts python3 skills/screener/screener.py
 
 # Run a single watcher evaluation cycle
-python3 watcher.py
+PYTHONPATH=scripts python3 skills/watcher/watcher.py
 
 # Health check only
-python3 supervisor.py --health
+PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --health
 
 # End-of-day review only
-python3 supervisor.py --eod
+PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --eod
 
 # Reset daily P&L counters (normally automatic at 9:25 AM ET)
-python3 supervisor.py --reset-daily
+PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --reset-daily
 
 # Startup verification only
-python3 executor.py --verify
+PYTHONPATH=scripts python3 skills/executor/executor.py --verify
 ```
 
 ### Backtesting and Discovery
 
 ```bash
 # Backtest RSI-2 on SPY and QQQ (5 years)
-python3 backtest_rsi2.py
+python3 scripts/backtest_rsi2.py
 
 # Backtest on sector ETFs and crypto
-python3 backtest_rsi2_expanded.py
+python3 scripts/backtest_rsi2_expanded.py
 
 # Full 26-instrument universe scan with tier classification
-python3 backtest_rsi2_universe.py
+python3 scripts/backtest_rsi2_universe.py
 
 # Discover new instruments from Alpaca's 12,000+ tradeable assets
-python3 discover_universe.py
-python3 discover_universe.py --max-candidates 50
+python3 scripts/discover_universe.py
+python3 scripts/discover_universe.py --max-candidates 50
 ```
 
 ## File Structure
@@ -189,25 +191,31 @@ python3 discover_universe.py --max-candidates 50
 ├── docker-compose.yml               # Redis + TimescaleDB
 ├── init-db/
 │   └── 001_create_schema.sql        # Database schema
-├── config.py                        # Shared config, Redis keys, defaults
-├── indicators.py                    # Technical indicators library
-├── notify.py                        # Telegram notification module
-├── screener.py                      # Screener Agent
-├── watcher.py                       # Watcher Agent
-├── portfolio_manager.py             # Portfolio Manager Agent
-├── executor.py                      # Trade Executor Agent (zero LLM)
-├── supervisor.py                    # Supervisor Agent
-├── verify_alpaca.py                 # Infrastructure verification
-├── backtest_rsi2.py                 # RSI-2 backtester (SPY/QQQ)
-├── backtest_rsi2_expanded.py        # RSI-2 on sector ETFs + crypto
-├── backtest_rsi2_universe.py        # Full universe scanner
-├── discover_universe.py             # Monthly discovery scanner
-├── skills/                          # Symlinked to OpenClaw workspace
-│   ├── screener/SKILL.md
-│   ├── watcher/SKILL.md
-│   ├── portfolio_manager/SKILL.md
-│   ├── executor/SKILL.md
-│   └── supervisor/SKILL.md
+├── scripts/
+│   ├── config.py                    # Shared config, Redis keys, defaults
+│   ├── indicators.py                # Technical indicators library
+│   ├── notify.py                    # Telegram notification module
+│   ├── verify_alpaca.py             # Infrastructure verification
+│   ├── backtest_rsi2.py             # RSI-2 backtester (SPY/QQQ)
+│   ├── backtest_rsi2_expanded.py    # RSI-2 on sector ETFs + crypto
+│   ├── backtest_rsi2_universe.py    # Full universe scanner
+│   └── discover_universe.py         # Monthly discovery scanner
+├── skills/                          # Agent code + OpenClaw skill definitions
+│   ├── screener/
+│   │   ├── screener.py              # Screener Agent
+│   │   └── SKILL.md
+│   ├── watcher/
+│   │   ├── watcher.py               # Watcher Agent
+│   │   └── SKILL.md
+│   ├── portfolio_manager/
+│   │   ├── portfolio_manager.py     # Portfolio Manager Agent
+│   │   └── SKILL.md
+│   ├── executor/
+│   │   ├── executor.py              # Trade Executor Agent (zero LLM)
+│   │   └── SKILL.md
+│   └── supervisor/
+│       ├── supervisor.py            # Supervisor Agent
+│       └── SKILL.md
 └── docs/
     ├── agentic_day_trading_system_report_v2.md
     ├── phase1_market_microstructure_constraints.md

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -5,10 +5,10 @@ executor.py — Trade Executor Agent
 The ONLY agent that interacts with the Alpaca API for order placement.
 Pure code — zero LLM. Enforces all safety rules deterministically.
 
-Usage:
-    python3 executor.py              # Process pending orders once
-    python3 executor.py --daemon     # Listen for orders continuously
-    python3 executor.py --verify     # Run startup verification only
+Usage (from repo root):
+    PYTHONPATH=scripts python3 skills/executor/executor.py              # Process pending orders once
+    PYTHONPATH=scripts python3 skills/executor/executor.py --daemon     # Listen for orders continuously
+    PYTHONPATH=scripts python3 skills/executor/executor.py --verify     # Run startup verification only
 """
 
 import json

--- a/skills/portfolio_manager/portfolio_manager.py
+++ b/skills/portfolio_manager/portfolio_manager.py
@@ -5,9 +5,9 @@ portfolio_manager.py — Portfolio Manager Agent
 Evaluates signals from the Watcher, sizes positions, checks risk constraints,
 and publishes approved orders to Redis for the Executor.
 
-Usage:
-    python3 portfolio_manager.py              # Process pending signals once
-    python3 portfolio_manager.py --daemon     # Listen for signals continuously
+Usage (from repo root):
+    PYTHONPATH=scripts python3 skills/portfolio_manager/portfolio_manager.py              # Process pending signals once
+    PYTHONPATH=scripts python3 skills/portfolio_manager/portfolio_manager.py --daemon     # Listen for signals continuously
 """
 
 import json

--- a/skills/screener/screener.py
+++ b/skills/screener/screener.py
@@ -5,9 +5,9 @@ screener.py — Screener Agent
 Monitors the active instrument universe for RSI-2 entry conditions.
 Runs end-of-day scans and publishes a ranked watchlist to Redis.
 
-Usage:
-    python3 screener.py              # Run one scan
-    python3 screener.py --daemon     # Run continuously on schedule
+Usage (from repo root):
+    PYTHONPATH=scripts python3 skills/screener/screener.py              # Run one scan
+    PYTHONPATH=scripts python3 skills/screener/screener.py --daemon     # Run continuously on schedule
 """
 
 import json

--- a/skills/supervisor/SKILL.md
+++ b/skills/supervisor/SKILL.md
@@ -183,7 +183,7 @@ monthly_summary(monthly_metrics)
 Re-run RSI-2 backtest on ALL instruments using rolling 12-month data.
 
 ```
-1. Run backtest_rsi2_universe.py on full list (active + disabled + failed)
+1. Run scripts/backtest_rsi2_universe.py on full list (active + disabled + failed)
 2. Apply tier thresholds:
    TIER 1: PF >= 2.0 AND WR >= 70% AND trades >= 8
    TIER 2: PF >= 1.5 AND WR >= 65%
@@ -197,7 +197,7 @@ Re-run RSI-2 backtest on ALL instruments using rolling 12-month data.
 ## MONTHLY JOB 2: Universe Discovery (15th of each month)
 
 ```
-1. Run discover_universe.py --max-candidates 50
+1. Run scripts/discover_universe.py --max-candidates 50
 2. Strict filters: >= 10 trades, avg trade > 0.30%, WR >= 65%, PF >= 1.5
 3. No leveraged/inverse ETFs, no bond ETFs with tiny moves
 4. New passes enter as Tier 3 (probation), max 5 per month

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -5,12 +5,12 @@ supervisor.py — Supervisor Agent
 Monitors system health, enforces circuit breakers, runs end-of-day reviews,
 sends Telegram summaries, and manages the instrument universe.
 
-Usage:
-    python3 supervisor.py                  # Run health check + EOD review
-    python3 supervisor.py --daemon         # Run continuously
-    python3 supervisor.py --health         # Health check only
-    python3 supervisor.py --eod            # End-of-day review only
-    python3 supervisor.py --reset-daily    # Reset daily P&L (run at market open)
+Usage (from repo root):
+    PYTHONPATH=scripts python3 skills/supervisor/supervisor.py                  # Run health check + EOD review
+    PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --daemon         # Run continuously
+    PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --health         # Health check only
+    PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --eod            # End-of-day review only
+    PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --reset-daily    # Reset daily P&L (run at market open)
 """
 
 import json

--- a/skills/watcher/watcher.py
+++ b/skills/watcher/watcher.py
@@ -5,9 +5,9 @@ watcher.py — Watcher Agent
 Monitors the watchlist and open positions for RSI-2 entry and exit signals.
 Publishes signals to Redis for the Portfolio Manager to evaluate.
 
-Usage:
-    python3 watcher.py              # Run one evaluation cycle
-    python3 watcher.py --daemon     # Run continuously
+Usage (from repo root):
+    PYTHONPATH=scripts python3 skills/watcher/watcher.py              # Run one evaluation cycle
+    PYTHONPATH=scripts python3 skills/watcher/watcher.py --daemon     # Run continuously
 """
 
 import json

--- a/start_trading_system.sh
+++ b/start_trading_system.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 # ── Configuration ───────────────────────────────────────────
 
 TRADING_DIR="${HOME}/trading-system"
+SCRIPTS_DIR="${TRADING_DIR}/scripts"
 LOG_DIR="${TRADING_DIR}/logs"
 PID_DIR="${TRADING_DIR}/pids"
 ENV_FILE="${HOME}/.trading_env"
@@ -102,8 +103,8 @@ check_infrastructure() {
 
     # Check that agent scripts exist
     for agent in "${AGENTS[@]}"; do
-        if [ ! -f "${TRADING_DIR}/${agent}.py" ]; then
-            log_error "Agent script not found: ${TRADING_DIR}/${agent}.py"
+        if [ ! -f "${TRADING_DIR}/skills/${agent}/${agent}.py" ]; then
+            log_error "Agent script not found: ${TRADING_DIR}/skills/${agent}/${agent}.py"
             exit 1
         fi
     done
@@ -134,9 +135,10 @@ start_system() {
     log_step "Running executor startup verification..."
     # shellcheck source=/dev/null
     source "$ENV_FILE"
+    export PYTHONPATH="${SCRIPTS_DIR}:${PYTHONPATH:-}"
     cd "$TRADING_DIR"
 
-    if ! python3 executor.py --verify 2>&1 | tee "${LOG_DIR}/verify_${DATE_SUFFIX}.log"; then
+    if ! python3 skills/executor/executor.py --verify 2>&1 | tee "${LOG_DIR}/verify_${DATE_SUFFIX}.log"; then
         log_error "Startup verification failed — aborting"
         exit 1
     fi
@@ -158,7 +160,7 @@ start_system() {
         log_step "Starting ${agent}..."
 
         # Start agent in background with logging
-        nohup python3 "${TRADING_DIR}/${agent}.py" --daemon \
+        nohup python3 "${TRADING_DIR}/skills/${agent}/${agent}.py" --daemon \
             >> "${LOG_DIR}/${agent}_${DATE_SUFFIX}.log" 2>&1 &
 
         agent_pid=$!


### PR DESCRIPTION
## Summary

- Agent scripts moved from repo root → `skills/{agent}/{agent}.py`; all `**File**:` references in `AGENTS.md` and usage docstrings in agent `.py` files updated accordingly
- Shared modules (`config`, `indicators`, `notify`, backtest scripts) moved to `scripts/`; all command examples in `README.md`, `AGENTS.md`, and `skills/supervisor/SKILL.md` updated with `scripts/` prefix
- `start_trading_system.sh`: fixed agent script paths, added `export PYTHONPATH="${SCRIPTS_DIR}:${PYTHONPATH:-}"` so agents can resolve bare imports (`import config`, `from indicators import ...`, `from notify import ...`) from `scripts/`

## Test plan

- [ ] `./start_trading_system.sh --status` — verify no "script not found" errors
- [ ] `PYTHONPATH=scripts python3 skills/executor/executor.py --verify` — startup verification passes
- [ ] `PYTHONPATH=scripts python3 skills/screener/screener.py` — single scan completes without import errors
- [ ] `python3 scripts/verify_alpaca.py` — infrastructure check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)