### PR TITLE
fix: unbuffered daemon logs and idle heartbeat

### DIFF
--- a/.claude/projects/-Users-texastoast-local-repos-trading-system/memory/project_trading_system.md
+++ b/.claude/projects/-Users-texastoast-local-repos-trading-system/memory/project_trading_system.md
@@ -13,7 +13,7 @@ Autonomous day trading system (`~/trading-system`) targeting a $5,000 account vi
 **How to apply:** Frame all changes in context of the five-agent pipeline and signal flow. Respect Rule 1 (no debt/shorting/margin) as a hard invariant.
 
 ## Current Status
-v1.0.0 — Stage 2 (agent development) complete. **Next step: integration testing** — run all five agents together on paper trading to verify full signal flow end-to-end.
+v1.0.2 — Stage 2 (agent development) complete. Directory restructure merged (PR #1). **Next step: integration testing** — run all five agents together on paper trading to verify full signal flow end-to-end.
 
 ## Five Agents (files in `skills/*/`)
 1. **Screener** (`skills/screener/screener.py`) — EOD scan at 4:15 PM ET, RSI-2 + regime via ADX on SPY, publishes watchlist to Redis. 3–5 LLM calls/day.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *.pyo
 .venv/
 venv/
+.claude/worktrees/
 
 # OS
 .DS_Store

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -410,10 +410,10 @@ def daemon_loop():
     pubsub = r.pubsub()
     pubsub.subscribe(Keys.APPROVED_ORDERS)
 
-    for msg in pubsub.listen():
+    while True:
         r.set(Keys.heartbeat("executor"), datetime.now().isoformat())
-
-        if msg['type'] != 'message':
+        msg = pubsub.get_message(timeout=60)
+        if msg is None or msg['type'] != 'message':
             continue
 
         try:

--- a/skills/portfolio_manager/portfolio_manager.py
+++ b/skills/portfolio_manager/portfolio_manager.py
@@ -344,11 +344,11 @@ def daemon_loop():
     pubsub = r.pubsub()
     pubsub.subscribe(Keys.SIGNALS)
 
-    for msg in pubsub.listen():
-        # Update heartbeat
+    while True:
+        # Update heartbeat on every iteration (fires every ~60s when idle)
         r.set(Keys.heartbeat("portfolio_manager"), datetime.now().isoformat())
-
-        if msg['type'] != 'message':
+        msg = pubsub.get_message(timeout=60)
+        if msg is None or msg['type'] != 'message':
             continue
 
         try:

--- a/start_trading_system.sh
+++ b/start_trading_system.sh
@@ -160,7 +160,7 @@ start_system() {
         log_step "Starting ${agent}..."
 
         # Start agent in background with logging
-        nohup python3 "${TRADING_DIR}/skills/${agent}/${agent}.py" --daemon \
+        nohup python3 -u "${TRADING_DIR}/skills/${agent}/${agent}.py" --daemon \
             >> "${LOG_DIR}/${agent}_${DATE_SUFFIX}.log" 2>&1 &
 
         agent_pid=$!


### PR DESCRIPTION
## Summary
- **Bug 1 (`start_trading_system.sh`):** Added `-u` flag to `python3` in the `nohup` launch line so stdout/stderr flush immediately to log files. Without this, Python buffers output in memory and daemon logs appear empty during normal operation.
- **Bug 2 (`executor.py`, `portfolio_manager.py`):** Replaced `for msg in pubsub.listen()` with a `while True` / `pubsub.get_message(timeout=60)` loop in both `daemon_loop()` functions. The heartbeat now fires on every loop iteration (~60s when idle) instead of only when a Redis message arrives — fixing false "agent down" reports from the Supervisor health check during market close and low-signal periods.

## Test plan
- [ ] Start system with `./start_trading_system.sh` and confirm log files populate immediately (no waiting for first message)
- [ ] Let executor and PM daemons run for >2 minutes with no signals and confirm `redis-cli GET trading:heartbeat:executor` and `trading:heartbeat:portfolio_manager` stay fresh
- [ ] Confirm Supervisor health check no longer reports executor/PM as down during idle periods
- [ ] Send a test signal through Redis and confirm orders still process correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)