### PR TITLE
fix: increase screener fetch window to 365 days for SMA-200

### DIFF
--- a/skills/screener/screener.py
+++ b/skills/screener/screener.py
@@ -28,7 +28,7 @@ from indicators import rsi, sma, atr, adx
 from notify import notify
 
 
-def fetch_daily_bars(symbol, stock_client, crypto_client, days=250):
+def fetch_daily_bars(symbol, stock_client, crypto_client, days=365):
     """Fetch enough daily bars for SMA-200 + indicator warmup."""
     end = datetime.now() - timedelta(hours=1)
     start = end - timedelta(days=days)


### PR DESCRIPTION
## Summary
- `fetch_daily_bars` in `skills/screener/screener.py` defaulted to `days=250` (calendar days), which only yields ~178 trading days — always below the `< 210` bar guard required for SMA-200 calculation. This caused the screener to return `None` for every symbol and never produce entry signals.
- Increased default to `days=365` (~260 trading days), which comfortably clears the 210-bar minimum.
- Checked `fetch_recent_bars` in `skills/watcher/watcher.py` — uses `days=10` with a `< 3` bar guard (for exit signal RSI checks only), no mismatch there.

## Test plan
- [ ] Run screener manually: `cd ~/trading-system && PYTHONPATH=scripts python3 skills/screener/screener.py`
- [ ] Confirm symbols are no longer rejected with insufficient bar data
- [ ] Confirm SMA-200 values are populated in screener output

🤖 Generated with [Claude Code](https://claude.com/claude-code)