### PR TITLE
fix: separate daemon agents from cron-triggered agents

### DIFF
--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -141,19 +141,34 @@ def run_health_check(r):
 
     issues = []
 
-    # Agent heartbeats
-    for agent in ["screener", "watcher", "portfolio_manager", "executor"]:
+    # Daemon agent heartbeats — should always be running, flag if stale > 5 min
+    for agent in ["executor", "portfolio_manager"]:
         hb = r.get(Keys.heartbeat(agent))
         if hb:
             last = datetime.fromisoformat(hb)
             age_min = (datetime.now() - last).total_seconds() / 60
-            if age_min > 60:
-                issues.append(f"{agent}: heartbeat {age_min:.0f}min old")
-                print(f"  ⚠️  {agent}: last heartbeat {age_min:.0f} min ago")
+            if age_min > 5:
+                issues.append(f"{agent}: heartbeat {age_min:.0f}min old (daemon may have crashed)")
+                print(f"  ⚠️  {agent}: last heartbeat {age_min:.0f} min ago — daemon may have crashed")
             else:
                 print(f"  ✅ {agent}: alive ({age_min:.0f}min ago)")
         else:
-            print(f"  ⚠️  {agent}: no heartbeat recorded")
+            issues.append(f"{agent}: no heartbeat — daemon not running")
+            print(f"  ⚠️  {agent}: no heartbeat — daemon not running")
+
+    # Cron-triggered agent heartbeats — gaps between runs are expected, flag only if stale > 6 hours
+    for agent in ["screener", "watcher"]:
+        hb = r.get(Keys.heartbeat(agent))
+        if hb:
+            last = datetime.fromisoformat(hb)
+            age_min = (datetime.now() - last).total_seconds() / 60
+            if age_min > 360:
+                issues.append(f"{agent}: last run {age_min:.0f}min ago (cron may have missed)")
+                print(f"  ⚠️  {agent}: last run {age_min:.0f} min ago — cron may have missed")
+            else:
+                print(f"  ✅ {agent}: last run {age_min:.0f}min ago")
+        else:
+            print(f"  ℹ️  {agent}: no runs yet")
 
     # Equity check
     equity = get_simulated_equity(r)

--- a/start_trading_system.sh
+++ b/start_trading_system.sh
@@ -2,8 +2,9 @@
 #
 # start_trading_system.sh — Trading System Startup Script
 #
-# Starts all five agents in the correct order with proper logging.
-# Each agent runs in the background with output logged to ~/trading-system/logs/
+# Starts daemon agents (executor, portfolio_manager) with proper logging.
+# Screener, watcher, and supervisor are managed by OpenClaw cron jobs, not this script.
+# Each daemon agent runs in the background with output logged to ~/trading-system/logs/
 #
 # Usage:
 #   ./start_trading_system.sh              # Start all agents
@@ -26,7 +27,7 @@ LOG_DIR="${TRADING_DIR}/logs"
 PID_DIR="${TRADING_DIR}/pids"
 ENV_FILE="${HOME}/.trading_env"
 
-AGENTS=("executor" "supervisor" "portfolio_manager" "screener" "watcher")
+AGENTS=("executor" "portfolio_manager")
 
 # Colors for output
 RED='\033[0;31m'
@@ -179,7 +180,7 @@ start_system() {
 
     echo ""
     echo "════════════════════════════════════════════════════════"
-    log_info "All agents started. Logs in ${LOG_DIR}/"
+    log_info "Daemon agents started. Logs in ${LOG_DIR}/"
     echo ""
     echo "  Monitor logs:    tail -f ${LOG_DIR}/*_${DATE_SUFFIX}.log"
     echo "  Check status:    $0 --status"
@@ -226,7 +227,7 @@ stop_system() {
     done
 
     echo ""
-    log_info "All agents stopped"
+    log_info "Daemon agents stopped"
 
     # Note: server-side stop-losses on Alpaca remain active
     echo ""
@@ -287,7 +288,7 @@ check_status() {
 
     echo ""
     if $all_running; then
-        log_info "All agents running"
+        log_info "All daemon agents running"
     else
         log_warn "Some agents are not running"
     fi
@@ -311,8 +312,8 @@ case "${1:-start}" in
     --help|-help|-h)
         echo "Usage: $0 [--start|--stop|--status|--restart|--help]"
         echo ""
-        echo "  --start     Start all agents (default)"
-        echo "  --stop      Stop all agents gracefully"
+        echo "  --start     Start daemon agents (default)"
+        echo "  --stop      Stop daemon agents gracefully"
         echo "  --status    Show agent status and system state"
         echo "  --restart   Stop then start"
         echo "  --help      Show this help"


### PR DESCRIPTION
## Summary
- **`start_trading_system.sh`:** Reduced `AGENTS` array from all five agents to only `executor` and `portfolio_manager`. Screener, watcher, and supervisor are now managed entirely by OpenClaw cron jobs and must not run as persistent daemons. Updated all comments and status messages accordingly.
- **`skills/supervisor/supervisor.py`:** Split the health check into two categories with appropriate staleness thresholds:
  - **Daemon agents** (`executor`, `portfolio_manager`): flagged as stale if heartbeat is older than **5 minutes** — these should always be running, so a stale heartbeat means the daemon crashed
  - **Cron-triggered agents** (`screener`, `watcher`): flagged as stale only if older than **6 hours** — scheduled gaps between runs are expected; a missing heartbeat shows "no runs yet" instead of a warning
  - Removed `supervisor` from the heartbeat check entirely — it sets its own heartbeat at the top of `run_health_check`, so self-checking is meaningless

## Test plan
- [ ] Run `./start_trading_system.sh` and confirm only executor and portfolio_manager are launched
- [ ] Run `./start_trading_system.sh --status` and confirm only the two daemons are shown
- [ ] Run `PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --health` and confirm daemon agents warn at 5 min, cron agents show "no runs yet" when missing, and supervisor itself is not in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)