### PR TITLE
fix: correct TimeFrame enum and tz-aware datetimes in fetch_intraday_bars

### DIFF
--- a/scripts/backtest_momentum_gappers.py
+++ b/scripts/backtest_momentum_gappers.py
@@ -33,6 +33,8 @@ import random
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field
 
+import pytz
+
 import numpy as np
 
 try:
@@ -41,7 +43,7 @@ try:
     from alpaca.trading.enums import AssetClass, AssetStatus
     from alpaca.data.historical import StockHistoricalDataClient
     from alpaca.data.requests import StockBarsRequest
-    from alpaca.data.timeframe import TimeFrame
+    from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 except ImportError:
     print("ERROR: alpaca-py not installed")
     sys.exit(1)
@@ -142,12 +144,13 @@ def fetch_intraday_bars(symbol, date_str, data_client):
     """Fetch 5-minute bars for a single symbol on a specific date."""
     try:
         day = datetime.strptime(date_str, "%Y-%m-%d")
-        start = day.replace(hour=9, minute=30)
-        end = day.replace(hour=16, minute=0)
+        et = pytz.timezone('America/New_York')
+        start = et.localize(day.replace(hour=9, minute=30))
+        end = et.localize(day.replace(hour=16, minute=0))
 
         request = StockBarsRequest(
             symbol_or_symbols=symbol,
-            timeframe=TimeFrame(5, "Min"),
+            timeframe=TimeFrame(5, TimeFrameUnit.Minute),
             start=start, end=end,
         )
         bars = data_client.get_stock_bars(request)


### PR DESCRIPTION
## Summary
Two bugs in `fetch_intraday_bars` in `scripts/backtest_momentum_gappers.py` caused it to silently return `None` for every gap event, resulting in 0 analyzed events and an empty report.

- **Fix 1 — `TimeFrameUnit` enum:** `TimeFrame(5, "Min")` → `TimeFrame(5, TimeFrameUnit.Minute)`. The string `"Min"` is not accepted by alpaca-py; the `TimeFrameUnit` enum is required. Added `TimeFrameUnit` to the `alpaca.data.timeframe` import.
- **Fix 2 — timezone-aware datetimes:** `start`/`end` were constructed as naive `datetime` objects (`day.replace(hour=9, minute=30)`). Alpaca requires timezone-aware datetimes. Added `import pytz` and localized both to `America/New_York` via `et.localize()`.

Verified: `TimeFrame(5, TimeFrameUnit.Minute)` with localized datetimes returns 79 bars for SPY.

## Test plan
- [ ] Run `PYTHONPATH=scripts python3 scripts/backtest_momentum_gappers.py --max-candidates 50 --months 3`
- [ ] Confirm "Successfully analyzed: N/N" shows a non-zero count
- [ ] Confirm report output includes intraday behavior stats and strategy simulations

🤖 Generated with [Claude Code](https://claude.com/claude-code)