### PR TITLE
fix: ET timestamp conversion and stop strategy list in backtest_momentum_gappers

### DIFF
--- a/scripts/backtest_momentum_gappers.py
+++ b/scripts/backtest_momentum_gappers.py
@@ -223,7 +223,8 @@ def analyze_intraday(event, intraday_bars):
     lows = [float(b.low) for b in intraday_bars]
     closes = [float(b.close) for b in intraday_bars]
     volumes = [float(b.volume) for b in intraday_bars]
-    times = [b.timestamp for b in intraday_bars]
+    et = pytz.timezone('America/New_York')
+    times = [b.timestamp.astimezone(et) for b in intraday_bars]
 
     open_price = opens[0]
     if open_price <= 0:
@@ -309,7 +310,7 @@ def simulate_strategies(events):
         if e.max_loss_from_open_pct <= -2.0:
             results['buy_open_stop_2pct'].append(-2.0)
         else:
-            results['buy_open_sell_close'].append(e.close_vs_open_pct)
+            results['buy_open_stop_2pct'].append(e.close_vs_open_pct)
 
         # Strategy 3: Buy break of 30-min opening range high, sell at close
         if e.broke_opening_range:


### PR DESCRIPTION
## Summary
Three bugs in `scripts/backtest_momentum_gappers.py` causing incorrect HOD timing stats and inflated/empty strategy trade counts.

- **Bug 1 — UTC timestamps in `analyze_intraday`:** Alpaca returns bar timestamps in UTC. `times` was built with raw `b.timestamp` values, so HOD times like `16:30` (UTC) and `20:00` (UTC) — which are `12:30 PM ET` and `4:00 PM ET` — were compared against ET-based thresholds, putting nearly all events in the "after 1 PM" bucket. Fixed by converting to ET: `b.timestamp.astimezone(et)`.

- **Bug 2 — Wrong list in stop strategy:** The `else` branch of `buy_open_stop_2pct` was appending `e.close_vs_open_pct` to `results['buy_open_sell_close']` instead of `results['buy_open_stop_2pct']`. This left Strategy 2 containing only stopped-out trades (-2.0 entries) while inflating Strategy 1's count.

- **Bug 3** resolves automatically once Bug 2 is fixed — `buy_open_sell_close` trade count now equals the number of analyzed events (e.g. 64), not exceeds it.

## Test plan
- [ ] Run `PYTHONPATH=scripts python3 scripts/backtest_momentum_gappers.py --max-candidates 50 --months 3`
- [ ] Confirm HOD timing buckets show a realistic spread across morning / midday / afternoon (not 90%+ in "after 1 PM")
- [ ] Confirm `buy_open_sell_close` trade count equals total analyzed events
- [ ] Confirm `buy_open_stop_2pct` trade count equals total analyzed events with a mix of -2.0 and close_vs_open entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)