### PR TITLE
fix: per-agent cron heartbeat thresholds in supervisor health check

### DIFF
--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -156,19 +156,22 @@ def run_health_check(r):
             issues.append(f"{agent}: no heartbeat — daemon not running")
             print(f"  ⚠️  {agent}: no heartbeat — daemon not running")
 
-    # Cron-triggered agent heartbeats — gaps between runs are expected, flag only if stale > 6 hours
-    for agent in ["screener", "watcher"]:
+    # Cron-triggered agent heartbeats — gaps between runs are expected
+    # screener: runs once daily at 4:15 PM ET, flag if stale > 25 hours
+    # watcher:  runs every 4 hours, flag if stale > 5 hours
+    cron_thresholds = {"screener": 25 * 60, "watcher": 5 * 60}  # in minutes
+    for agent, threshold_min in cron_thresholds.items():
         hb = r.get(Keys.heartbeat(agent))
         if hb:
             last = datetime.fromisoformat(hb)
             age_min = (datetime.now() - last).total_seconds() / 60
-            if age_min > 360:
+            if age_min > threshold_min:
                 issues.append(f"{agent}: last run {age_min:.0f}min ago (cron may have missed)")
                 print(f"  ⚠️  {agent}: last run {age_min:.0f} min ago — cron may have missed")
             else:
                 print(f"  ✅ {agent}: last run {age_min:.0f}min ago")
         else:
-            print(f"  ℹ️  {agent}: no runs yet")
+            print(f"  ℹ️  {agent}: awaiting first run")
 
     # Equity check
     equity = get_simulated_equity(r)


### PR DESCRIPTION
## Summary
The shared 6-hour staleness threshold for cron-triggered agents caused false warnings for the screener. The screener runs once daily at 4:15 PM ET, so by the next afternoon its heartbeat is legitimately ~24 hours old — well past the 6-hour threshold and triggering spurious alerts on every health check.

Replaced the shared threshold with per-agent values that match each agent's actual cron schedule:

| Agent | Schedule | Old threshold | New threshold |
|-------|----------|--------------|---------------|
| `screener` | Once daily at 4:15 PM ET | 6 hours | **25 hours** |
| `watcher` | Every 4 hours | 6 hours | **5 hours** |
| `executor` | Daemon (always on) | 5 min | 5 min (unchanged) |
| `portfolio_manager` | Daemon (always on) | 5 min | 5 min (unchanged) |

Also updated the no-heartbeat message for cron agents from `"no runs yet"` to `"awaiting first run"`.

## Test plan
- [ ] Run health check in the morning after screener last ran at 4:15 PM the previous day — confirm no false warning
- [ ] Simulate a missed screener run (heartbeat > 25 hours old) — confirm warning fires
- [ ] Confirm watcher warns after 5 hours of no runs, not 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)