### PR TITLE
fix: Redis state consistency — 8 data flow issues

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -124,8 +124,8 @@ class Keys:
     PDT_COUNT = "trading:pdt:count"
     RISK_MULTIPLIER = "trading:risk_multiplier"
     SYSTEM_STATUS = "trading:system_status"
-    STRATEGY_PARAMS = "trading:strategy_params"
-    DISABLED_INSTRUMENTS = "trading:disabled_instruments"
+    # Note: disabled instruments are stored in universe["disabled"], not a separate key
+    # Note: strategy params are not yet implemented
 
     @staticmethod
     def heartbeat(agent: str) -> str:
@@ -134,10 +134,6 @@ class Keys:
     @staticmethod
     def whipsaw(symbol: str) -> str:
         return f"trading:whipsaw:{symbol}"
-
-    @staticmethod
-    def position(symbol: str) -> str:
-        return f"trading:position:{symbol}"
 
 
 # ── Redis Connection ────────────────────────────────────────
@@ -152,6 +148,8 @@ def init_redis_state(r: redis.Redis):
         r.set(Keys.UNIVERSE, json.dumps(DEFAULT_UNIVERSE))
     if not r.exists(Keys.TIERS):
         r.set(Keys.TIERS, json.dumps(DEFAULT_TIERS))
+    if not r.exists(Keys.REGIME):
+        r.set(Keys.REGIME, json.dumps({"regime": "RANGING", "adx": 20, "initialized_default": True}))
     if not r.exists(Keys.SIMULATED_EQUITY):
         r.set(Keys.SIMULATED_EQUITY, str(INITIAL_CAPITAL))
     if not r.exists(Keys.PEAK_EQUITY):

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -392,8 +392,16 @@ def verify_startup(trading_client, r):
     else:
         print(f"  ✅ No open positions")
 
+    # Sync PDT count from Alpaca (source of truth)
+    alpaca_pdt = int(account.daytrade_count or 0)
+    redis_pdt = int(r.get(Keys.PDT_COUNT) or 0)
+    if alpaca_pdt != redis_pdt:
+        r.set(Keys.PDT_COUNT, str(alpaca_pdt))
+        print(f"  ⚠️ PDT count synced: Redis had {redis_pdt}, Alpaca has {alpaca_pdt}")
+    else:
+        print(f"  ✅ PDT count: {alpaca_pdt}/3")
+
     print(f"  ✅ Account equity: ${float(account.equity):,.2f} (paper)")
-    print(f"  ✅ Day trade count: {account.daytrade_count}")
 
     if not all_ok:
         critical_alert("Startup verification FAILED — check logs")

--- a/skills/portfolio_manager/portfolio_manager.py
+++ b/skills/portfolio_manager/portfolio_manager.py
@@ -116,8 +116,8 @@ def evaluate_entry_signal(r, signal):
         return None, f"Position already exists for {symbol} (qty={existing_qty})"
 
     # ── Disabled instrument check ──
-    disabled_raw = r.get(Keys.DISABLED_INSTRUMENTS)
-    disabled = json.loads(disabled_raw) if disabled_raw else []
+    universe = json.loads(r.get(Keys.UNIVERSE) or json.dumps(config.DEFAULT_UNIVERSE))
+    disabled = universe.get("disabled", [])
     if symbol in disabled:
         return None, f"{symbol} is currently disabled"
 

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -327,10 +327,12 @@ def reset_daily(r):
     """Reset daily counters — run at market open."""
     r.set(Keys.DAILY_PNL, "0.0")
 
-    # Reset PDT counter based on rolling window
-    # TODO: implement proper 5-day rolling window
-    # For now, just sync with Alpaca
-    print("[Supervisor] Daily counters reset.")
+    # Reset peak equity to current equity at session start so drawdown
+    # is measured within the current trading period, not against a stale peak
+    equity = get_simulated_equity(r)
+    r.set(Keys.PEAK_EQUITY, str(round(equity, 2)))
+
+    print(f"[Supervisor] Daily counters reset. Peak equity set to ${equity:,.2f}.")
 
     # Re-enable if was in daily_halt
     if r.get(Keys.SYSTEM_STATUS) == "daily_halt":

--- a/skills/watcher/watcher.py
+++ b/skills/watcher/watcher.py
@@ -78,6 +78,7 @@ def generate_entry_signals(r, stock_client, crypto_client):
     """Check watchlist for entry conditions."""
     watchlist_raw = r.get(Keys.WATCHLIST)
     if not watchlist_raw:
+        print("  [Watcher] No watchlist found — screener may not have run yet")
         return []
 
     watchlist = json.loads(watchlist_raw)
@@ -194,8 +195,8 @@ def generate_exit_signals(r, stock_client, crypto_client):
                 "exit_price": stop_price,
                 "reason": f"Stop-loss hit at {stop_price}",
             }
-            # Set whipsaw cooldown
-            r.set(Keys.whipsaw(symbol), datetime.now().isoformat())
+            # Set whipsaw cooldown (auto-expires after 24h)
+            r.set(Keys.whipsaw(symbol), datetime.now().isoformat(), ex=86400)
 
         # RSI-2 exit (> 60)
         elif not np.isnan(rsi2_val) and rsi2_val > config.RSI2_EXIT:


### PR DESCRIPTION
## Summary
- **#1 DISABLED_INSTRUMENTS mismatch** — PM read from `Keys.DISABLED_INSTRUMENTS` (never written). Supervisor stores disabled list in `universe["disabled"]`. PM now reads from there.
- **#2 REGIME has no default** — Watcher/PM silently fell back to RANGING before screener ran. Now initialized in `init_redis_state()`.
- **#3 Dead keys removed** — `STRATEGY_PARAMS` and `DISABLED_INSTRUMENTS` keys removed from `Keys` class (neither was ever written to).
- **#4 PDT_COUNT synced on startup** — Executor now syncs Redis PDT count from `account.daytrade_count` at startup, preventing desync after crash/restart.
- **#5 Watcher logs missing watchlist** — Instead of silently returning empty when screener hasn't run.
- **#6 Unused `Keys.position()` removed** — All position data lives in `Keys.POSITIONS` dict.
- **#7 Whipsaw keys get 24h TTL** — `ex=86400` prevents stale entries from accumulating forever.
- **#8 PEAK_EQUITY resets daily** — `reset_daily()` now sets peak to current equity so drawdown is measured from session start.

## Test plan
- [ ] Verify PM correctly blocks disabled instruments when supervisor triggers circuit breaker (drawdown > 10%)
- [ ] Verify `init_redis_state` creates `trading:regime` with RANGING default
- [ ] Restart executor daemon — verify PDT count syncs from Alpaca account
- [ ] Run watcher before screener — verify "No watchlist found" log message appears
- [ ] Trigger a stop-loss — verify whipsaw key has TTL (`redis-cli TTL trading:whipsaw:XLI`)
- [ ] Run `--reset-daily` — verify peak equity updates to current equity

🤖 Generated with [Claude Code](https://claude.com/claude-code)