### PR TITLE
fix supervisor EOD review crashing silently before daily summary

### DIFF
--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -37,8 +37,8 @@ import requests
 from datetime import datetime
 
 
-BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
-CHAT_ID = os.environ.get("TELEGRAM_CHAT_ID")
+BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+CHAT_ID = os.environ.get("TELEGRAM_CHAT_ID", "").strip()
 
 API_URL = f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage" if BOT_TOKEN else None
 

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -212,7 +212,10 @@ def run_eod_review(r):
     dd = get_drawdown(r)
     daily_pnl = float(r.get(Keys.DAILY_PNL) or 0)
     regime_raw = r.get(Keys.REGIME)
-    regime = json.loads(regime_raw).get("regime", "UNKNOWN") if regime_raw else "UNKNOWN"
+    try:
+        regime = json.loads(regime_raw).get("regime", "UNKNOWN") if regime_raw else "UNKNOWN"
+    except (json.JSONDecodeError, AttributeError):
+        regime = "UNKNOWN"
     positions = json.loads(r.get(Keys.POSITIONS) or "{}")
 
     # Calculate start-of-day equity
@@ -410,12 +413,20 @@ def main():
     elif args.health:
         run_health_check(r)
     elif args.eod:
-        run_eod_review(r)
+        try:
+            run_eod_review(r)
+        except Exception as e:
+            print(f"[Supervisor] EOD review error: {e}")
+            critical_alert(f"EOD review failed: {e}")
     elif args.reset_daily:
         reset_daily(r)
     else:
         run_health_check(r)
-        run_eod_review(r)
+        try:
+            run_eod_review(r)
+        except Exception as e:
+            print(f"[Supervisor] EOD review error: {e}")
+            critical_alert(f"EOD review failed: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `run_eod_review()` was crashing before reaching `daily_summary()` due to an unguarded `json.loads(regime_raw)` on line 215 — if the Redis `trading:regime` key is malformed (e.g. set to a raw string instead of JSON), it throws `JSONDecodeError` and the function dies silently
- `main()` had no `try/except` around `run_eod_review()` for the `--eod` and default modes, so crashes were invisible (no `critical_alert`, no syslog error beyond the exit code)
- `notify.py` now strips whitespace from `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` to guard against accidental spaces in `.trading_env`

## Why notifications were intermittent

The executor daemon (trade entry/exit/critical alerts) loads env vars once at startup and calls `notify.py` in-process — always works. The supervisor runs as a cron job / OpenClaw agent where a single exception before `daily_summary()` silently kills the notification with no feedback.

## Test plan

- [ ] On openboog: `PYTHONPATH=scripts python3 skills/supervisor/supervisor.py --eod` — should produce daily summary Telegram message even if `trading:regime` is absent or malformed
- [ ] Corrupt the regime key (`redis-cli set trading:regime "bad"`) and confirm the script still sends the daily summary with `regime: UNKNOWN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)