### PR TITLE
fix .trading_env overridden by agent shell environment

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -27,7 +27,7 @@ def _load_trading_env():
             key, _, val = line.partition("=")
             key = key.strip()
             val = val.strip().strip('"').strip("'")
-            os.environ.setdefault(key, val)
+            os.environ[key] = val
 
 
 _load_trading_env()


### PR DESCRIPTION
## Summary

`_load_trading_env()` in `config.py` used `os.environ.setdefault()`, which only sets a key if it is **not already present**. When the OpenClaw agent runs `supervisor.py`, its shell environment already has `TELEGRAM_CHAT_ID` set to an agent-specific value — so `.trading_env` was silently skipped and notifications went to the wrong Telegram channel.

Changed to direct assignment (`os.environ[key] = val`) so `.trading_env` is always the authoritative source, regardless of what's already in the environment.

## Test plan

- [ ] Deploy to openboog, run `trading-eod-review` from OpenClaw, confirm daily summary arrives in the correct Telegram channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)