### PR TITLE
run universe discovery twice weekly (Mon + Wed)

### DIFF
--- a/cron/trading-system-cron
+++ b/cron/trading-system-cron
@@ -31,5 +31,5 @@ TRADING_ENV=/home/linuxuser/.trading_env
 # --- Monthly universe re-validation (1st of month, 6:00 AM ET) -------------
 0 6 1 * *  linuxuser  . $TRADING_ENV && cd $TRADING_HOME && PYTHONPATH=$TRADING_HOME/scripts python3 skills/supervisor/supervisor.py --revalidation 2>&1 | logger -t trading-revalidation
 
-# --- Monthly universe discovery (15th of month, 6:00 AM ET) ----------------
-0 6 15 * *  linuxuser  . $TRADING_ENV && cd $TRADING_HOME && PYTHONPATH=$TRADING_HOME/scripts python3 scripts/discover_universe.py --max-candidates 50 2>&1 | logger -t trading-discovery
+# --- Universe discovery (Monday and Wednesday, 6:00 AM ET) -----------------
+0 6 * * 1,3  linuxuser  . $TRADING_ENV && cd $TRADING_HOME && PYTHONPATH=$TRADING_HOME/scripts python3 scripts/discover_universe.py --max-candidates 50 2>&1 | logger -t trading-discovery


### PR DESCRIPTION
## Summary

Changed `trading-discovery` cron schedule from monthly (15th of month) to every Monday and Wednesday at 6:00 AM ET.

Before: `0 6 15 * *`
After: `0 6 * * 1,3`

## Test plan

- [ ] Deploy updated cron file to openboog
- [ ] Confirm discovery runs Monday morning via `journalctl -t trading-discovery`

🤖 Generated with [Claude Code](https://claude.com/claude-code)