### PR TITLE
scaffold Phoenix LiveView trading dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ The system runs one proven strategy (RSI-2 mean reversion) across multiple instr
 
 - **VPS**: Ubuntu 24.04 (tested on Vultr, hostname `openboog`)
 - **Python**: 3.12+ (system Python works; avoid 3.14 for alpaca-py compatibility)
-- **Docker**: For Redis and TimescaleDB containers
+- **Docker**: For Redis, TimescaleDB, and the dashboard container
 - **Alpaca account**: Free paper trading account at [alpaca.markets](https://alpaca.markets)
 - **OpenClaw**: Installed with Node.js 22.16+ for LLM orchestration
 - **Telegram bot** (optional): For trade alerts and daily summaries
+- **Tailscale**: Installed on the VPS and your devices for private dashboard access
 
 ## Quick Start
 
@@ -47,6 +48,8 @@ export ALPACA_SECRET_KEY="your-paper-secret"
 export TSDB_PASSWORD="changeme_in_env_file"
 export TELEGRAM_BOT_TOKEN=""    # optional — see Telegram Setup below
 export TELEGRAM_CHAT_ID=""      # optional
+export TAILSCALE_HOSTNAME=""    # your Tailscale hostname, e.g. openboog.tail1234.ts.net
+export DASHBOARD_SECRET_KEY_BASE=""  # generate with: mix phx.gen.secret (64+ chars)
 EOF
 chmod 600 ~/.trading_env
 

--- a/dashboard/.formatter.exs
+++ b/dashboard/.formatter.exs
@@ -1,0 +1,6 @@
+[
+  import_deps: [:ecto, :ecto_sql, :phoenix],
+  subdirectories: ["priv/*/migrations"],
+  plugins: [Phoenix.LiveView.HTMLFormatter],
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"]
+]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,63 @@
+# dashboard/Dockerfile
+# Multi-stage build for the Phoenix LiveView trading dashboard.
+#
+# Stage 1 (builder): compiles deps, builds assets, creates the Mix release.
+# Stage 2 (runtime): minimal image that just runs the release binary.
+#
+# Build is triggered automatically by `docker compose up --build`.
+
+# ── Stage 1: Builder ────────────────────────────────────────────────────────
+FROM elixir:1.18-otp-27-alpine AS builder
+
+WORKDIR /app
+
+ENV MIX_ENV=prod
+
+# Build tools
+RUN apk add --no-cache build-base git nodejs npm
+
+# Hex + rebar
+RUN mix local.hex --force && mix local.rebar --force
+
+# Fetch deps first (separate layer — only rebuilds when mix.exs/mix.lock change)
+# mix.lock is generated on first `mix deps.get` and committed for reproducible builds.
+# If mix.lock doesn't exist yet, `mix deps.get` creates it.
+COPY mix.exs ./
+COPY mix.lock* ./
+RUN mix deps.get --only prod
+RUN mix deps.compile
+
+# Build assets (Tailwind + esbuild)
+COPY assets assets
+COPY priv priv
+RUN mix assets.deploy
+
+# Compile app and create release
+COPY lib lib
+COPY config config
+RUN mix compile
+RUN mix release
+
+# ── Stage 2: Runtime ────────────────────────────────────────────────────────
+FROM ubuntu:24.04 AS runtime
+
+# Runtime deps only (no build tools)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl3 \
+    libncurses6 \
+    libstdc++6 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the compiled release from the builder stage
+COPY --from=builder /app/_build/prod/rel/dashboard ./
+
+ENV PHX_SERVER=true
+ENV MIX_ENV=prod
+
+EXPOSE 4000
+
+# Bin entrypoint — reads PHX_HOST, SECRET_KEY_BASE, DATABASE_URL, REDIS_URL from env
+CMD ["bin/dashboard", "start"]

--- a/dashboard/assets/css/app.css
+++ b/dashboard/assets/css/app.css
@@ -1,0 +1,28 @@
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
+
+/* Custom scrollbar styling for dark theme */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: #1f2937;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #374151;
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #4b5563;
+}
+
+/* LiveView loading indicator */
+[data-phx-loading] {
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}

--- a/dashboard/assets/js/app.js
+++ b/dashboard/assets/js/app.js
@@ -1,0 +1,16 @@
+// app.js — Phoenix LiveView entry point
+
+import {Socket} from "phoenix"
+import {LiveSocket} from "phoenix_live_view"
+
+// CSRF token for LiveView WebSocket authentication
+let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
+
+let liveSocket = new LiveSocket("/live", Socket, {
+  longPollFallbackMs: 2500,
+  params: {_csrf_token: csrfToken}
+})
+
+// Connect and expose for debugging
+liveSocket.connect()
+window.liveSocket = liveSocket

--- a/dashboard/assets/tailwind.config.js
+++ b/dashboard/assets/tailwind.config.js
@@ -1,0 +1,18 @@
+// tailwind.config.js
+const path = require("path")
+
+module.exports = {
+  content: [
+    "../lib/dashboard_web/**/*.{heex,ex,js}",
+    "../lib/dashboard_web.ex",
+  ],
+  darkMode: "class",
+  theme: {
+    extend: {
+      fontFamily: {
+        mono: ["JetBrains Mono", "Fira Code", "Consolas", "ui-monospace", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+}

--- a/dashboard/config/config.exs
+++ b/dashboard/config/config.exs
@@ -1,0 +1,46 @@
+import Config
+
+config :dashboard,
+  ecto_repos: [Dashboard.Repo],
+  generators: [timestamp_type: :utc_datetime]
+
+config :dashboard, DashboardWeb.Endpoint,
+  url: [host: "localhost"],
+  adapter: Bandit.PhoenixAdapter,
+  render_errors: [
+    formats: [html: DashboardWeb.ErrorHTML, json: DashboardWeb.ErrorJSON],
+    layout: false
+  ],
+  pubsub_server: Dashboard.PubSub,
+  live_view: [signing_salt: "trading_dashboard_salt"]
+
+config :dashboard, Dashboard.Repo,
+  migration_primary_key: [name: :id, type: :bigserial]
+
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]
+
+config :phoenix, :json_library, Jason
+
+config :esbuild,
+  version: "0.17.11",
+  dashboard: [
+    args: ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets
+             --external:/fonts/* --external:/images/*),
+    cd: Path.expand("../assets", __DIR__),
+    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+  ]
+
+config :tailwind,
+  version: "3.4.3",
+  dashboard: [
+    args: ~w(
+      --config=tailwind.config.js
+      --input=css/app.css
+      --output=../priv/static/assets/app.css
+    ),
+    cd: Path.expand("../assets", __DIR__)
+  ]
+
+import_config "#{config_env()}.exs"

--- a/dashboard/config/dev.exs
+++ b/dashboard/config/dev.exs
@@ -1,0 +1,35 @@
+import Config
+
+config :dashboard, DashboardWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4000],
+  check_origin: false,
+  code_reloader: true,
+  debug_errors: true,
+  secret_key_base: "local_dev_secret_key_base_at_least_64_chars_long_for_development_only",
+  watchers: [
+    esbuild: {Esbuild, :install_and_run, [:dashboard, ~w(--sourcemap=inline --watch)]},
+    tailwind: {Tailwind, :install_and_run, [:dashboard, ~w(--watch)]}
+  ]
+
+config :dashboard, DashboardWeb.Endpoint,
+  live_reload: [
+    patterns: [
+      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
+      ~r"priv/gettext/.*(po)$",
+      ~r"lib/dashboard_web/(controllers|live|components)/.*(ex|heex)$"
+    ]
+  ]
+
+config :dashboard, Dashboard.Repo,
+  username: "trader",
+  password: "changeme_in_env_file",
+  hostname: "localhost",
+  database: "trading",
+  stacktrace: true,
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 5
+
+config :logger, level: :debug
+config :phoenix, :stacktrace_depth, 20
+config :phoenix, :plug_init_mode, :runtime
+config :phoenix_live_view, :debug_heex_annotations, true

--- a/dashboard/config/prod.exs
+++ b/dashboard/config/prod.exs
@@ -1,0 +1,10 @@
+import Config
+
+config :dashboard, DashboardWeb.Endpoint,
+  cache_static_manifest: "priv/static/cache_manifest.json"
+
+config :logger, level: :info
+
+config :logger, :console,
+  format: "$time $metadata[$level] $message\n",
+  metadata: [:request_id]

--- a/dashboard/config/runtime.exs
+++ b/dashboard/config/runtime.exs
@@ -1,0 +1,45 @@
+import Config
+
+# Runtime configuration — all secrets come from environment variables.
+# In Docker, these are injected by docker-compose.yml.
+# In dev, set them in config/dev.exs or your shell.
+
+if config_env() == :prod do
+  database_url =
+    System.get_env("DATABASE_URL") ||
+      raise "DATABASE_URL environment variable is required"
+
+  config :dashboard, Dashboard.Repo,
+    url: database_url,
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
+    # TimescaleDB lives on the same Docker network — use service name
+    socket_options: []
+
+  secret_key_base =
+    System.get_env("SECRET_KEY_BASE") ||
+      raise "SECRET_KEY_BASE environment variable is required (generate with: mix phx.gen.secret)"
+
+  host = System.get_env("PHX_HOST") || "localhost"
+  port = String.to_integer(System.get_env("PORT") || "4000")
+
+  config :dashboard, DashboardWeb.Endpoint,
+    url: [host: host, port: 443, scheme: "https"],
+    http: [
+      ip: {0, 0, 0, 0},
+      port: port
+    ],
+    secret_key_base: secret_key_base
+end
+
+# Redis URL — used by RedisPoller and RedisSubscriber
+# Default for local dev: redis://localhost:6379
+# In Docker: redis://redis:6379
+config :dashboard, :redis_url,
+  System.get_env("REDIS_URL") || "redis://localhost:6379"
+
+# Alpaca API credentials — used by MarketClock for /v2/clock
+config :dashboard, :alpaca_api_key,
+  System.get_env("ALPACA_API_KEY") || ""
+
+config :dashboard, :alpaca_secret_key,
+  System.get_env("ALPACA_SECRET_KEY") || ""

--- a/dashboard/lib/dashboard/application.ex
+++ b/dashboard/lib/dashboard/application.ex
@@ -1,0 +1,44 @@
+defmodule Dashboard.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    redis_url = Application.get_env(:dashboard, :redis_url, "redis://localhost:6379")
+
+    children = [
+      # Telemetry
+      DashboardWeb.Telemetry,
+
+      # Database
+      Dashboard.Repo,
+
+      # PubSub — used by LiveView and background processes
+      {Phoenix.PubSub, name: Dashboard.PubSub},
+
+      # Redis connections
+      # One connection for GET/MGET polling
+      {Redix, {redis_url, [name: :redix]}},
+      # One connection dedicated to pub/sub (blocked while subscribed)
+      {Redix, {redis_url, [name: :redix_pubsub]}},
+
+      # Background GenServers
+      Dashboard.RedisPoller,
+      Dashboard.RedisSubscriber,
+      Dashboard.MarketClock,
+
+      # Phoenix endpoint (must be last)
+      DashboardWeb.Endpoint
+    ]
+
+    opts = [strategy: :one_for_one, name: Dashboard.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  @impl true
+  def config_change(changed, _new, removed) do
+    DashboardWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+end

--- a/dashboard/lib/dashboard/market_clock.ex
+++ b/dashboard/lib/dashboard/market_clock.ex
@@ -1,0 +1,82 @@
+defmodule Dashboard.MarketClock do
+  @moduledoc """
+  GenServer that polls the Alpaca /v2/clock endpoint every 30 seconds.
+  Broadcasts market open/closed state to "dashboard:clock".
+
+  Response shape:
+    %{
+      "is_open" => true/false,
+      "next_open" => "2025-06-10T09:30:00-04:00",
+      "next_close" => "2025-06-10T16:00:00-04:00",
+      "timestamp" => "2025-06-10T14:23:11-04:00"
+    }
+  """
+
+  use GenServer
+  require Logger
+
+  @poll_interval_ms 30_000
+  @alpaca_base_url "https://paper-api.alpaca.markets"
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{clock: nil}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    # Fetch immediately, then poll every 30s
+    send(self(), :fetch)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:fetch, state) do
+    new_state =
+      case fetch_clock() do
+        {:ok, clock} ->
+          Phoenix.PubSub.broadcast(Dashboard.PubSub, "dashboard:clock", {:clock_update, clock})
+          %{state | clock: clock}
+
+        {:error, reason} ->
+          Logger.warning("MarketClock: fetch failed: #{inspect(reason)}")
+          state
+      end
+
+    Process.send_after(self(), :fetch, @poll_interval_ms)
+    {:noreply, new_state}
+  end
+
+  defp fetch_clock do
+    api_key = Application.get_env(:dashboard, :alpaca_api_key, "")
+    secret_key = Application.get_env(:dashboard, :alpaca_secret_key, "")
+
+    if api_key == "" do
+      # No credentials — return a placeholder so the UI still renders
+      {:ok,
+       %{
+         "is_open" => false,
+         "next_open" => nil,
+         "next_close" => nil,
+         "timestamp" => DateTime.to_iso8601(DateTime.utc_now()),
+         "error" => "no_credentials"
+       }}
+    else
+      case Req.get("#{@alpaca_base_url}/v2/clock",
+             headers: [
+               {"APCA-API-KEY-ID", api_key},
+               {"APCA-API-SECRET-KEY", secret_key}
+             ],
+             receive_timeout: 5_000
+           ) do
+        {:ok, %{status: 200, body: body}} ->
+          {:ok, body}
+
+        {:ok, %{status: status}} ->
+          {:error, "HTTP #{status}"}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+end

--- a/dashboard/lib/dashboard/queries.ex
+++ b/dashboard/lib/dashboard/queries.ex
@@ -1,0 +1,56 @@
+defmodule Dashboard.Queries do
+  @moduledoc """
+  Query helpers for the trading dashboard.
+  All queries are read-only — the dashboard never writes to the database.
+  """
+
+  import Ecto.Query
+  alias Dashboard.Repo
+  alias Dashboard.Schemas.{Trade, Signal, DailySummary, Position}
+
+  @doc "Recent trades for the trades table."
+  def recent_trades(limit \\ 20) do
+    Trade.recent(limit) |> Repo.all()
+  end
+
+  @doc "Recent signals from the signals table."
+  def recent_signals(limit \\ 50) do
+    Signal.recent(limit) |> Repo.all()
+  end
+
+  @doc "Last N days of daily summaries."
+  def daily_summaries(days \\ 14) do
+    DailySummary.recent(days) |> Repo.all()
+  end
+
+  @doc "Currently open positions from the database."
+  def open_positions do
+    Position.open() |> Repo.all()
+  end
+
+  @doc "Aggregate win/loss stats over a date range."
+  def win_loss_stats(days_back \\ 30) do
+    cutoff = Date.add(Date.utc_today(), -days_back)
+
+    from(s in DailySummary,
+      where: s.date >= ^cutoff,
+      select: %{
+        total_trades: sum(s.trades_executed),
+        winning_trades: sum(s.winning_trades),
+        losing_trades: sum(s.losing_trades),
+        total_pnl: sum(s.daily_pnl),
+        total_fees: sum(s.total_fees)
+      }
+    )
+    |> Repo.one()
+  end
+
+  @doc "Total realized P&L from the trades table."
+  def total_realized_pnl do
+    from(t in Trade,
+      where: t.side == "sell" and not is_nil(t.realized_pnl),
+      select: sum(t.realized_pnl)
+    )
+    |> Repo.one()
+  end
+end

--- a/dashboard/lib/dashboard/redis_poller.ex
+++ b/dashboard/lib/dashboard/redis_poller.ex
@@ -1,0 +1,116 @@
+defmodule Dashboard.RedisPoller do
+  @moduledoc """
+  GenServer that polls Redis every 2 seconds and broadcasts state to LiveView subscribers.
+
+  Uses pipelined MGET to fetch all relevant keys in a single round trip.
+  Broadcasts to PubSub topic "dashboard:state".
+  """
+
+  use GenServer
+  require Logger
+
+  @poll_interval_ms 2_000
+
+  # Redis keys to fetch on each poll (mirrors Keys class in config.py)
+  @redis_keys [
+    "trading:simulated_equity",
+    "trading:peak_equity",
+    "trading:daily_pnl",
+    "trading:drawdown",
+    "trading:pdt:count",
+    "trading:risk_multiplier",
+    "trading:system_status",
+    "trading:regime",
+    "trading:positions",
+    "trading:watchlist",
+    "trading:heartbeat:screener",
+    "trading:heartbeat:watcher",
+    "trading:heartbeat:portfolio_manager",
+    "trading:heartbeat:executor",
+    "trading:heartbeat:supervisor"
+  ]
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    schedule_poll()
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    case poll_redis() do
+      {:ok, parsed} ->
+        Phoenix.PubSub.broadcast(Dashboard.PubSub, "dashboard:state", {:state_update, parsed})
+
+      {:error, reason} ->
+        Logger.warning("RedisPoller: fetch failed: #{inspect(reason)}")
+    end
+
+    schedule_poll()
+    {:noreply, state}
+  end
+
+  defp schedule_poll do
+    Process.send_after(self(), :poll, @poll_interval_ms)
+  end
+
+  defp poll_redis do
+    commands = Enum.map(@redis_keys, fn key -> ["GET", key] end)
+
+    case Redix.pipeline(:redix, commands) do
+      {:ok, values} ->
+        pairs = Enum.zip(@redis_keys, values)
+        parsed = parse_redis_values(pairs)
+        {:ok, parsed}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp parse_redis_values(pairs) do
+    Enum.reduce(pairs, %{}, fn {key, val}, acc ->
+      parsed_val = parse_value(key, val)
+      Map.put(acc, key, parsed_val)
+    end)
+  end
+
+  # JSON blobs
+  defp parse_value(key, val)
+       when key in ["trading:regime", "trading:positions", "trading:watchlist"] do
+    case val do
+      nil -> nil
+      v -> Jason.decode(v) |> elem(1)
+    end
+  end
+
+  # Plain numeric strings
+  defp parse_value(key, val)
+       when key in [
+              "trading:simulated_equity",
+              "trading:peak_equity",
+              "trading:daily_pnl",
+              "trading:drawdown",
+              "trading:risk_multiplier"
+            ] do
+    case val do
+      nil -> nil
+      v -> Float.parse(v) |> then(fn {f, _} -> f end)
+    end
+  end
+
+  # Integer count
+  defp parse_value("trading:pdt:count", val) do
+    case val do
+      nil -> 0
+      v -> String.to_integer(v)
+    end
+  end
+
+  # Everything else: return as-is (status, heartbeat timestamps)
+  defp parse_value(_key, val), do: val
+end

--- a/dashboard/lib/dashboard/redis_subscriber.ex
+++ b/dashboard/lib/dashboard/redis_subscriber.ex
@@ -1,0 +1,76 @@
+defmodule Dashboard.RedisSubscriber do
+  @moduledoc """
+  GenServer that subscribes to the Redis `trading:signals` pub/sub channel.
+
+  Whenever the Watcher publishes a signal, this process receives it and
+  broadcasts it to the PubSub topic "dashboard:signals" so the LiveView
+  can update the live signal feed without waiting for the next poll cycle.
+  """
+
+  use GenServer
+  require Logger
+
+  @channel "trading:signals"
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    # Subscribe using the dedicated pubsub connection
+    case Redix.PubSub.subscribe(:redix_pubsub, @channel, self()) do
+      {:ok, _ref} ->
+        Logger.info("RedisSubscriber: subscribed to #{@channel}")
+        {:ok, state}
+
+      {:error, reason} ->
+        Logger.error("RedisSubscriber: subscribe failed: #{inspect(reason)}")
+        # Retry after 5 seconds
+        Process.send_after(self(), :retry_subscribe, 5_000)
+        {:ok, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:redix_pubsub, _client, _ref, :subscribed, %{channel: ch}}, state) do
+    Logger.info("RedisSubscriber: confirmed subscription to #{ch}")
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:redix_pubsub, _client, _ref, :message, %{channel: @channel, payload: payload}},
+        state
+      ) do
+    case Jason.decode(payload) do
+      {:ok, signal} ->
+        Phoenix.PubSub.broadcast(Dashboard.PubSub, "dashboard:signals", {:new_signal, signal})
+
+      {:error, reason} ->
+        Logger.warning("RedisSubscriber: failed to decode signal: #{inspect(reason)}")
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info({:redix_pubsub, _client, _ref, :disconnected, _}, state) do
+    Logger.warning("RedisSubscriber: disconnected from Redis, will retry...")
+    Process.send_after(self(), :retry_subscribe, 5_000)
+    {:noreply, state}
+  end
+
+  def handle_info(:retry_subscribe, state) do
+    case Redix.PubSub.subscribe(:redix_pubsub, @channel, self()) do
+      {:ok, _ref} ->
+        Logger.info("RedisSubscriber: re-subscribed to #{@channel}")
+
+      {:error, reason} ->
+        Logger.error("RedisSubscriber: retry failed: #{inspect(reason)}, retrying in 10s")
+        Process.send_after(self(), :retry_subscribe, 10_000)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+end

--- a/dashboard/lib/dashboard/repo.ex
+++ b/dashboard/lib/dashboard/repo.ex
@@ -1,0 +1,5 @@
+defmodule Dashboard.Repo do
+  use Ecto.Repo,
+    otp_app: :dashboard,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/dashboard/lib/dashboard/schemas/daily_summary.ex
+++ b/dashboard/lib/dashboard/schemas/daily_summary.ex
@@ -1,0 +1,33 @@
+defmodule Dashboard.Schemas.DailySummary do
+  @moduledoc "Read-only Ecto schema for the `daily_summary` table."
+
+  use Ecto.Schema
+  import Ecto.Query
+
+  @primary_key {:date, :date, autogenerate: false}
+
+  schema "daily_summary" do
+    field :starting_equity, :decimal
+    field :ending_equity, :decimal
+    field :daily_pnl, :decimal
+    field :daily_pnl_pct, :decimal
+    field :peak_equity, :decimal
+    field :drawdown_pct, :decimal
+    field :trades_executed, :integer
+    field :day_trades_used, :integer
+    field :winning_trades, :integer
+    field :losing_trades, :integer
+    field :total_fees, :decimal
+    field :total_llm_cost, :decimal
+    field :strategies_active, {:array, :string}
+    field :supervisor_notes, :string
+    field :regime, :string
+  end
+
+  @doc "Return the last N days of summaries, newest first."
+  def recent(days \\ 14) do
+    from s in __MODULE__,
+      order_by: [desc: s.date],
+      limit: ^days
+  end
+end

--- a/dashboard/lib/dashboard/schemas/position.ex
+++ b/dashboard/lib/dashboard/schemas/position.ex
@@ -1,0 +1,39 @@
+defmodule Dashboard.Schemas.Position do
+  @moduledoc "Read-only Ecto schema for the `positions` table."
+
+  use Ecto.Schema
+  import Ecto.Query
+
+  schema "positions" do
+    field :opened_at, :utc_datetime_usec
+    field :closed_at, :utc_datetime_usec
+    field :symbol, :string
+    field :side, :string
+    field :quantity, :decimal
+    field :entry_price, :decimal
+    field :exit_price, :decimal
+    field :stop_price, :decimal
+    field :target_price, :decimal
+    field :strategy, :string
+    field :asset_class, :string
+    field :is_day_trade, :boolean
+    field :alpaca_order_id, :string
+    field :realized_pnl, :decimal
+    field :status, :string
+  end
+
+  @doc "Return all currently open positions."
+  def open do
+    from p in __MODULE__,
+      where: p.status == "open",
+      order_by: [asc: p.opened_at]
+  end
+
+  @doc "Return the N most recently closed positions."
+  def recent_closed(limit \\ 10) do
+    from p in __MODULE__,
+      where: p.status != "open",
+      order_by: [desc: p.closed_at],
+      limit: ^limit
+  end
+end

--- a/dashboard/lib/dashboard/schemas/signal.ex
+++ b/dashboard/lib/dashboard/schemas/signal.ex
@@ -1,0 +1,29 @@
+defmodule Dashboard.Schemas.Signal do
+  @moduledoc "Read-only Ecto schema for the `signals` TimescaleDB hypertable."
+
+  use Ecto.Schema
+  import Ecto.Query
+
+  @primary_key false
+
+  schema "signals" do
+    field :id, :integer
+    field :time, :utc_datetime_usec
+    field :symbol, :string
+    field :strategy, :string
+    field :signal_type, :string
+    field :direction, :string
+    field :confidence, :decimal
+    field :regime, :string
+    field :indicators, :map
+    field :acted_on, :boolean
+    field :rejection_reason, :string
+  end
+
+  @doc "Return the N most recent signals, newest first."
+  def recent(limit \\ 50) do
+    from s in __MODULE__,
+      order_by: [desc: s.time],
+      limit: ^limit
+  end
+end

--- a/dashboard/lib/dashboard/schemas/trade.ex
+++ b/dashboard/lib/dashboard/schemas/trade.ex
@@ -1,0 +1,39 @@
+defmodule Dashboard.Schemas.Trade do
+  @moduledoc "Read-only Ecto schema for the `trades` TimescaleDB hypertable."
+
+  use Ecto.Schema
+  import Ecto.Query
+
+  @primary_key false
+
+  schema "trades" do
+    field :id, :integer
+    field :time, :utc_datetime_usec
+    field :symbol, :string
+    field :side, :string
+    field :quantity, :decimal
+    field :price, :decimal
+    field :total_value, :decimal
+    field :fees, :decimal
+    field :order_id, :string
+    field :strategy, :string
+    field :asset_class, :string
+    field :realized_pnl, :decimal
+    field :notes, :string
+  end
+
+  @doc "Return the N most recent trades, newest first."
+  def recent(limit \\ 20) do
+    from t in __MODULE__,
+      order_by: [desc: t.time],
+      limit: ^limit
+  end
+
+  @doc "Return trades for a specific symbol."
+  def for_symbol(symbol, limit \\ 50) do
+    from t in __MODULE__,
+      where: t.symbol == ^symbol,
+      order_by: [desc: t.time],
+      limit: ^limit
+  end
+end

--- a/dashboard/lib/dashboard_web.ex
+++ b/dashboard/lib/dashboard_web.ex
@@ -1,0 +1,82 @@
+defmodule DashboardWeb do
+  @moduledoc """
+  Entry point for DashboardWeb. Defines the helper functions used by
+  controllers, live views, components, and more.
+  """
+
+  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+
+  def router do
+    quote do
+      use Phoenix.Router, helpers: false
+      import Plug.Conn
+      import Phoenix.Controller
+      import Phoenix.LiveView.Router
+    end
+  end
+
+  def channel do
+    quote do
+      use Phoenix.Channel
+    end
+  end
+
+  def controller do
+    quote do
+      use Phoenix.Controller,
+        formats: [:html, :json],
+        layouts: [html: DashboardWeb.Layouts]
+
+      import Plug.Conn
+      unquote(verified_routes())
+    end
+  end
+
+  def live_view do
+    quote do
+      use Phoenix.LiveView,
+        layout: {DashboardWeb.Layouts, :app}
+
+      unquote(html_helpers())
+    end
+  end
+
+  def live_component do
+    quote do
+      use Phoenix.LiveComponent
+      unquote(html_helpers())
+    end
+  end
+
+  def html do
+    quote do
+      use Phoenix.Component
+      import Phoenix.Controller,
+        only: [get_csrf_token: 0, view_module: 1, view_template: 1]
+
+      unquote(html_helpers())
+    end
+  end
+
+  defp html_helpers do
+    quote do
+      use Phoenix.HTML
+      import Phoenix.LiveView.Helpers
+      import DashboardWeb.CoreComponents
+      unquote(verified_routes())
+    end
+  end
+
+  def verified_routes do
+    quote do
+      use Phoenix.VerifiedRoutes,
+        endpoint: DashboardWeb.Endpoint,
+        router: DashboardWeb.Router,
+        statics: DashboardWeb.static_paths()
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/dashboard/lib/dashboard_web/components/core_components.ex
+++ b/dashboard/lib/dashboard_web/components/core_components.ex
@@ -1,0 +1,82 @@
+defmodule DashboardWeb.CoreComponents do
+  @moduledoc """
+  Core UI components for the trading dashboard.
+  """
+
+  use Phoenix.Component
+
+  @doc "Renders a simple card container with a title."
+  attr :title, :string, required: true
+  attr :class, :string, default: ""
+  slot :inner_block, required: true
+
+  def card(assigns) do
+    ~H"""
+    <div class={["bg-gray-800 rounded-lg border border-gray-700 p-4", @class]}>
+      <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3"><%= @title %></h2>
+      <%= render_slot(@inner_block) %>
+    </div>
+    """
+  end
+
+  @doc "Renders a status badge."
+  attr :status, :string, required: true
+
+  def status_badge(assigns) do
+    {bg, text} =
+      case assigns.status do
+        "active" -> {"bg-green-900/50 border-green-700", "text-green-400"}
+        "halted" -> {"bg-red-900/50 border-red-700", "text-red-400"}
+        "caution" -> {"bg-yellow-900/50 border-yellow-700", "text-yellow-400"}
+        _ -> {"bg-gray-900/50 border-gray-700", "text-gray-400"}
+      end
+
+    assigns = assign(assigns, :bg, bg) |> assign(:text, text)
+
+    ~H"""
+    <span class={[
+      "inline-flex items-center px-2 py-0.5 rounded border text-xs font-medium uppercase",
+      @bg,
+      @text
+    ]}>
+      <%= @status %>
+    </span>
+    """
+  end
+
+  @doc "Renders a P&L value with appropriate color."
+  attr :value, :any, required: true
+  attr :suffix, :string, default: ""
+
+  def pnl(assigns) do
+    color =
+      cond do
+        is_nil(assigns.value) -> "text-gray-400"
+        Decimal.compare(Decimal.new("0"), to_decimal(assigns.value)) == :gt -> "text-red-400"
+        Decimal.compare(to_decimal(assigns.value), Decimal.new("0")) == :gt -> "text-green-400"
+        true -> "text-gray-400"
+      end
+
+    assigns = assign(assigns, :color, color)
+
+    ~H"""
+    <span class={@color}>
+      <%= format_pnl(@value) %><%= @suffix %>
+    </span>
+    """
+  end
+
+  defp to_decimal(v) when is_float(v), do: Decimal.from_float(v)
+  defp to_decimal(v) when is_integer(v), do: Decimal.new(v)
+  defp to_decimal(%Decimal{} = v), do: v
+  defp to_decimal(v) when is_binary(v), do: Decimal.new(v)
+  defp to_decimal(_), do: Decimal.new("0")
+
+  defp format_pnl(nil), do: "—"
+
+  defp format_pnl(v) do
+    d = to_decimal(v)
+    prefix = if Decimal.compare(d, Decimal.new("0")) == :gt, do: "+", else: ""
+    "#{prefix}#{Decimal.round(d, 2)}"
+  end
+end

--- a/dashboard/lib/dashboard_web/components/layouts.ex
+++ b/dashboard/lib/dashboard_web/components/layouts.ex
@@ -1,0 +1,5 @@
+defmodule DashboardWeb.Layouts do
+  use DashboardWeb, :html
+
+  embed_templates "layouts/*"
+end

--- a/dashboard/lib/dashboard_web/controllers/error_html.ex
+++ b/dashboard/lib/dashboard_web/controllers/error_html.ex
@@ -1,0 +1,9 @@
+defmodule DashboardWeb.ErrorHTML do
+  use DashboardWeb, :html
+
+  # Renders 404 and 500 error pages.
+  # Use Phoenix's default templates which render "404.html" etc.
+  def render(template, _assigns) do
+    Phoenix.Controller.status_message_from_template(template)
+  end
+end

--- a/dashboard/lib/dashboard_web/controllers/error_json.ex
+++ b/dashboard/lib/dashboard_web/controllers/error_json.ex
@@ -1,0 +1,4 @@
+defmodule DashboardWeb.ErrorJSON do
+  def render("404.json", _assigns), do: %{errors: %{detail: "Not Found"}}
+  def render("500.json", _assigns), do: %{errors: %{detail: "Internal Server Error"}}
+end

--- a/dashboard/lib/dashboard_web/controllers/health_controller.ex
+++ b/dashboard/lib/dashboard_web/controllers/health_controller.ex
@@ -1,0 +1,8 @@
+defmodule DashboardWeb.HealthController do
+  use DashboardWeb, :controller
+
+  @doc "Simple liveness check for Docker healthcheck and load balancers."
+  def index(conn, _params) do
+    json(conn, %{status: "ok"})
+  end
+end

--- a/dashboard/lib/dashboard_web/endpoint.ex
+++ b/dashboard/lib/dashboard_web/endpoint.ex
@@ -1,0 +1,43 @@
+defmodule DashboardWeb.Endpoint do
+  use Phoenix.Endpoint, otp_app: :dashboard
+
+  # Session configuration
+  @session_options [
+    store: :cookie,
+    key: "_dashboard_key",
+    signing_salt: "trading_salt",
+    same_site: "Lax"
+  ]
+
+  socket "/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [session: @session_options]],
+    longpoll: [connect_info: [session: @session_options]]
+
+  # Serve static files from priv/static
+  plug Plug.Static,
+    at: "/",
+    from: :dashboard,
+    gzip: false,
+    only: DashboardWeb.static_paths()
+
+  # Code reloading (dev only)
+  if code_reloading? do
+    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+    plug Phoenix.LiveReloader
+    plug Phoenix.CodeReloader
+    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :dashboard
+  end
+
+  plug Plug.RequestId
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: Phoenix.json_library()
+
+  plug Plug.MethodOverride
+  plug Plug.Head
+  plug Plug.Session, @session_options
+  plug DashboardWeb.Router
+end

--- a/dashboard/lib/dashboard_web/layouts/app.html.heex
+++ b/dashboard/lib/dashboard_web/layouts/app.html.heex
@@ -1,0 +1,3 @@
+<main class="min-h-screen">
+  <%= @inner_content %>
+</main>

--- a/dashboard/lib/dashboard_web/layouts/root.html.heex
+++ b/dashboard/lib/dashboard_web/layouts/root.html.heex
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="csrf-token" content={get_csrf_token()} />
+    <title>Trading Dashboard</title>
+    <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
+    <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
+    </script>
+  </head>
+  <body class="bg-gray-900 text-gray-100 antialiased min-h-screen">
+    <%= @inner_content %>
+  </body>
+</html>

--- a/dashboard/lib/dashboard_web/live/dashboard_live.ex
+++ b/dashboard/lib/dashboard_web/live/dashboard_live.ex
@@ -1,0 +1,264 @@
+defmodule DashboardWeb.DashboardLive do
+  @moduledoc """
+  Main trading dashboard LiveView.
+
+  State comes from two sources:
+    1. Redis (via RedisPoller broadcasts every 2s): live equity, positions,
+       watchlist, agent heartbeats, regime, system status
+    2. TimescaleDB (via Queries, loaded on mount and refreshed every 60s):
+       recent trades, daily summaries
+
+  Signals from the Watcher appear in real-time via RedisSubscriber pub/sub.
+  The market clock comes from MarketClock every 30s.
+  """
+
+  use DashboardWeb, :live_view
+  alias Dashboard.Queries
+
+  # Keep only the last 30 signals in the live feed
+  @max_signals 30
+
+  # Refresh DB-backed data every 60 seconds
+  @db_refresh_ms 60_000
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Dashboard.PubSub, "dashboard:state")
+      Phoenix.PubSub.subscribe(Dashboard.PubSub, "dashboard:signals")
+      Phoenix.PubSub.subscribe(Dashboard.PubSub, "dashboard:clock")
+      Process.send_after(self(), :refresh_db, @db_refresh_ms)
+    end
+
+    socket =
+      socket
+      |> assign(:page_title, "Trading Dashboard")
+      # Redis state (updated by poller)
+      |> assign(:equity, nil)
+      |> assign(:peak_equity, nil)
+      |> assign(:daily_pnl, nil)
+      |> assign(:drawdown, nil)
+      |> assign(:pdt_count, 0)
+      |> assign(:risk_multiplier, 1.0)
+      |> assign(:system_status, "unknown")
+      |> assign(:regime, nil)
+      |> assign(:redis_positions, %{})
+      |> assign(:watchlist, [])
+      |> assign(:heartbeats, %{})
+      # Live signal feed (from pub/sub)
+      |> assign(:live_signals, [])
+      # Market clock
+      |> assign(:clock, nil)
+      # DB-backed (loaded async after connection)
+      |> assign(:recent_trades, [])
+      |> assign(:daily_summaries, [])
+
+    # Load DB data if connected (will be async after LV socket upgrade)
+    socket =
+      if connected?(socket) do
+        load_db_data(socket)
+      else
+        socket
+      end
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_info({:state_update, state}, socket) do
+    heartbeats = %{
+      "screener" => state["trading:heartbeat:screener"],
+      "watcher" => state["trading:heartbeat:watcher"],
+      "portfolio_manager" => state["trading:heartbeat:portfolio_manager"],
+      "executor" => state["trading:heartbeat:executor"],
+      "supervisor" => state["trading:heartbeat:supervisor"]
+    }
+
+    socket =
+      socket
+      |> assign(:equity, state["trading:simulated_equity"])
+      |> assign(:peak_equity, state["trading:peak_equity"])
+      |> assign(:daily_pnl, state["trading:daily_pnl"])
+      |> assign(:drawdown, state["trading:drawdown"])
+      |> assign(:pdt_count, state["trading:pdt:count"] || 0)
+      |> assign(:risk_multiplier, state["trading:risk_multiplier"])
+      |> assign(:system_status, state["trading:system_status"] || "unknown")
+      |> assign(:regime, state["trading:regime"])
+      |> assign(:redis_positions, state["trading:positions"] || %{})
+      |> assign(:watchlist, state["trading:watchlist"] || [])
+      |> assign(:heartbeats, heartbeats)
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:new_signal, signal}, socket) do
+    signals = [signal | socket.assigns.live_signals] |> Enum.take(@max_signals)
+    {:noreply, assign(socket, :live_signals, signals)}
+  end
+
+  def handle_info({:clock_update, clock}, socket) do
+    {:noreply, assign(socket, :clock, clock)}
+  end
+
+  def handle_info(:refresh_db, socket) do
+    Process.send_after(self(), :refresh_db, @db_refresh_ms)
+    {:noreply, load_db_data(socket)}
+  end
+
+  defp load_db_data(socket) do
+    socket
+    |> assign(:recent_trades, Queries.recent_trades(15))
+    |> assign(:daily_summaries, Queries.daily_summaries(7))
+  end
+
+  # ── Helpers ──────────────────────────────────────────────────────────────────
+
+  defp heartbeat_status(nil), do: :stale
+  defp heartbeat_status(ts) when is_binary(ts) do
+    case DateTime.from_iso8601(ts) do
+      {:ok, dt, _} ->
+        age_minutes = DateTime.diff(DateTime.utc_now(), dt, :second) / 60
+
+        cond do
+          age_minutes < 10 -> :ok
+          age_minutes < 30 -> :warning
+          true -> :stale
+        end
+
+      _ ->
+        :stale
+    end
+  end
+
+  defp heartbeat_age(nil), do: "never"
+  defp heartbeat_age(ts) when is_binary(ts) do
+    case DateTime.from_iso8601(ts) do
+      {:ok, dt, _} ->
+        age = DateTime.diff(DateTime.utc_now(), dt, :second)
+
+        cond do
+          age < 60 -> "#{age}s ago"
+          age < 3600 -> "#{div(age, 60)}m ago"
+          true -> "#{div(age, 3600)}h ago"
+        end
+
+      _ ->
+        "unknown"
+    end
+  end
+
+  defp regime_emoji(nil), do: "❓"
+  defp regime_emoji(%{"regime" => "UPTREND"}), do: "📈"
+  defp regime_emoji(%{"regime" => "DOWNTREND"}), do: "📉"
+  defp regime_emoji(%{"regime" => "RANGING"}), do: "➡️"
+  defp regime_emoji(_), do: "❓"
+
+  defp regime_name(nil), do: "Unknown"
+  defp regime_name(%{"regime" => r}), do: r
+  defp regime_name(_), do: "Unknown"
+
+  defp adx_value(nil), do: nil
+  defp adx_value(%{"adx" => adx}), do: adx
+  defp adx_value(_), do: nil
+
+  defp format_price(nil), do: "—"
+  defp format_price(v) when is_float(v), do: "$#{:erlang.float_to_binary(v, [decimals: 2])}"
+  defp format_price(v), do: "$#{v}"
+
+  defp format_equity(nil), do: "—"
+  defp format_equity(v), do: "$#{:erlang.float_to_binary(v + 0.0, [decimals: 2])}"
+
+  defp format_pct(nil), do: "—"
+  defp format_pct(v), do: "#{:erlang.float_to_binary(v + 0.0, [decimals: 2])}%"
+
+  defp pnl_class(nil), do: "text-gray-400"
+  defp pnl_class(v) when v > 0, do: "text-green-400"
+  defp pnl_class(v) when v < 0, do: "text-red-400"
+  defp pnl_class(_), do: "text-gray-400"
+
+  defp signal_icon(%{"signal_type" => "entry"}), do: "📊"
+  defp signal_icon(%{"signal_type" => "take_profit"}), do: "✅"
+  defp signal_icon(%{"signal_type" => "stop_loss"}), do: "🛑"
+  defp signal_icon(%{"signal_type" => "time_stop"}), do: "⏰"
+  defp signal_icon(_), do: "•"
+
+  defp signal_detail(%{"signal_type" => "entry"} = s) do
+    rsi = get_in(s, ["indicators", "rsi2"])
+    tier = s["tier"]
+    stop = s["suggested_stop"]
+    "RSI-2=#{format_float(rsi)} Stop=#{format_price(stop)} T#{tier}"
+  end
+
+  defp signal_detail(%{"signal_type" => type} = s) do
+    pnl = s["pnl_pct"]
+    reason = s["reason"] || type
+    if pnl, do: "#{reason} P&L=#{format_signed_pct(pnl)}", else: reason
+  end
+
+  defp format_float(nil), do: "—"
+  defp format_float(v) when is_float(v), do: :erlang.float_to_binary(v, [decimals: 1])
+  defp format_float(v), do: "#{v}"
+
+  defp format_signed_pct(nil), do: "—"
+  defp format_signed_pct(v) when v > 0, do: "+#{:erlang.float_to_binary(v + 0.0, [decimals: 2])}%"
+  defp format_signed_pct(v), do: "#{:erlang.float_to_binary(v + 0.0, [decimals: 2])}%"
+
+  defp signal_time(%{"time" => t}) when is_binary(t) do
+    case DateTime.from_iso8601(t) do
+      {:ok, dt, _} ->
+        dt
+        |> DateTime.shift_zone!("America/New_York")
+        |> Calendar.strftime("%-I:%M %p")
+
+      _ ->
+        t
+    end
+  end
+
+  defp signal_time(_), do: ""
+
+  defp market_status(nil), do: {"UNKNOWN", "text-gray-400"}
+  defp market_status(%{"is_open" => true}), do: {"OPEN", "text-green-400"}
+  defp market_status(%{"is_open" => false}), do: {"CLOSED", "text-gray-500"}
+
+  defp position_pnl_pct(pos, equity) when is_map(pos) and is_float(equity) do
+    entry = get_float(pos, "entry_price")
+    qty = get_float(pos, "quantity")
+
+    with true <- entry > 0,
+         true <- qty > 0,
+         true <- equity > 0 do
+      # We don't have current price in Redis positions, show cost as % of equity
+      cost = entry * qty
+      cost / equity * 100
+    else
+      _ -> nil
+    end
+  end
+
+  defp position_pnl_pct(_, _), do: nil
+
+  defp get_float(map, key) do
+    case map[key] do
+      v when is_float(v) -> v
+      v when is_integer(v) -> v * 1.0
+      v when is_binary(v) -> String.to_float(v)
+      _ -> 0.0
+    end
+  end
+
+  defp tier_badge(1), do: {"T1", "bg-yellow-900/40 text-yellow-400 border-yellow-700"}
+  defp tier_badge(2), do: {"T2", "bg-blue-900/40 text-blue-400 border-blue-700"}
+  defp tier_badge(3), do: {"T3", "bg-gray-900/40 text-gray-400 border-gray-600"}
+  defp tier_badge(_), do: {"T?", "bg-gray-900/40 text-gray-500 border-gray-700"}
+
+  defp drawdown_class(nil), do: "text-green-400"
+  defp drawdown_class(v) when v < 5.0, do: "text-green-400"
+  defp drawdown_class(v) when v < 10.0, do: "text-yellow-400"
+  defp drawdown_class(v) when v < 15.0, do: "text-orange-400"
+  defp drawdown_class(_), do: "text-red-400"
+
+  defp heartbeat_dot(:ok), do: "bg-green-500"
+  defp heartbeat_dot(:warning), do: "bg-yellow-500"
+  defp heartbeat_dot(:stale), do: "bg-red-500"
+end

--- a/dashboard/lib/dashboard_web/live/dashboard_live.html.heex
+++ b/dashboard/lib/dashboard_web/live/dashboard_live.html.heex
@@ -1,0 +1,307 @@
+<%# Trading Dashboard — RSI-2 Mean Reversion System %>
+
+<div class="min-h-screen bg-gray-900 text-gray-100 p-4 space-y-4">
+
+  <%# ── Header ──────────────────────────────────────────────────── %>
+  <div class="flex items-center justify-between">
+    <h1 class="text-lg font-bold text-white tracking-tight">
+      RSI-2 Trading System
+    </h1>
+    <div class="flex items-center gap-4 text-sm">
+      <%# Market status %>
+      <% {mkt_label, mkt_class} = market_status(@clock) %>
+      <span class={["font-medium", mkt_class]}><%= mkt_label %></span>
+      <%# System status badge %>
+      <.status_badge status={@system_status} />
+      <%# Last update time %>
+      <span class="text-gray-600 text-xs">live</span>
+    </div>
+  </div>
+
+  <%# ── Key Metrics Row ─────────────────────────────────────────── %>
+  <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3">
+
+    <div class="bg-gray-800 rounded-lg border border-gray-700 p-3">
+      <div class="text-xs text-gray-500 uppercase tracking-wider">Equity</div>
+      <div class="text-xl font-bold text-white mt-1"><%= format_equity(@equity) %></div>
+      <div class="text-xs text-gray-600 mt-0.5">peak <%= format_equity(@peak_equity) %></div>
+    </div>
+
+    <div class="bg-gray-800 rounded-lg border border-gray-700 p-3">
+      <div class="text-xs text-gray-500 uppercase tracking-wider">Daily P&L</div>
+      <div class={["text-xl font-bold mt-1", pnl_class(@daily_pnl)]}>
+        <%= format_equity(@daily_pnl) %>
+      </div>
+      <div class="text-xs text-gray-600 mt-0.5">&nbsp;</div>
+    </div>
+
+    <div class="bg-gray-800 rounded-lg border border-gray-700 p-3">
+      <div class="text-xs text-gray-500 uppercase tracking-wider">Drawdown</div>
+      <div class={["text-xl font-bold mt-1", drawdown_class(@drawdown)]}>
+        <%= format_pct(@drawdown) %>
+      </div>
+      <div class="text-xs text-gray-600 mt-0.5">from peak</div>
+    </div>
+
+    <div class="bg-gray-800 rounded-lg border border-gray-700 p-3">
+      <div class="text-xs text-gray-500 uppercase tracking-wider">PDT Used</div>
+      <div class={["text-xl font-bold mt-1", if(@pdt_count >= 3, do: "text-red-400", else: "text-white")]}>
+        <%= @pdt_count %>/3
+      </div>
+      <div class="text-xs text-gray-600 mt-0.5">day trades</div>
+    </div>
+
+    <div class="bg-gray-800 rounded-lg border border-gray-700 p-3">
+      <div class="text-xs text-gray-500 uppercase tracking-wider">Regime</div>
+      <div class="text-lg font-bold text-white mt-1">
+        <%= regime_emoji(@regime) %> <%= regime_name(@regime) %>
+      </div>
+      <div class="text-xs text-gray-600 mt-0.5">
+        ADX <%= if adx_value(@regime), do: :erlang.float_to_binary(adx_value(@regime) + 0.0, decimals: 1), else: "—" %>
+      </div>
+    </div>
+
+    <div class="bg-gray-800 rounded-lg border border-gray-700 p-3">
+      <div class="text-xs text-gray-500 uppercase tracking-wider">Risk Mult.</div>
+      <div class={["text-xl font-bold mt-1", if((@risk_multiplier || 1.0) < 1.0, do: "text-yellow-400", else: "text-white")]}>
+        <%= if @risk_multiplier, do: :erlang.float_to_binary(@risk_multiplier + 0.0, decimals: 2), else: "1.00" %>×
+      </div>
+      <div class="text-xs text-gray-600 mt-0.5">position size</div>
+    </div>
+  </div>
+
+  <%# ── Agent Heartbeats ────────────────────────────────────────── %>
+  <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
+    <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Agents</h2>
+    <div class="flex flex-wrap gap-4">
+      <%= for agent <- ["screener", "watcher", "portfolio_manager", "executor", "supervisor"] do %>
+        <% hb = @heartbeats[agent]
+           status = heartbeat_status(hb)
+           age = heartbeat_age(hb)
+           label = String.replace(agent, "_", " ") |> String.capitalize() %>
+        <div class="flex items-center gap-2">
+          <span class={["w-2 h-2 rounded-full flex-shrink-0", heartbeat_dot(status)]}></span>
+          <div>
+            <div class="text-sm font-medium text-gray-200 capitalize"><%= label %></div>
+            <div class="text-xs text-gray-600"><%= age %></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <%# ── Main Content: 2-column layout ──────────────────────────── %>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+
+    <%# ── Left: Positions + Watchlist ── %>
+    <div class="space-y-4">
+
+      <%# Open Positions %>
+      <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Open Positions (<%= map_size(@redis_positions) %>)
+        </h2>
+        <%= if map_size(@redis_positions) == 0 do %>
+          <p class="text-sm text-gray-600 italic">No open positions</p>
+        <% else %>
+          <div class="space-y-2">
+            <%= for {_key, pos} <- @redis_positions do %>
+              <% {tier_label, tier_class} = tier_badge(pos["tier"]) %>
+              <div class="flex items-center justify-between py-2 border-b border-gray-700/50 last:border-0">
+                <div class="flex items-center gap-2">
+                  <span class="font-mono font-semibold text-white"><%= pos["symbol"] %></span>
+                  <span class={["text-xs px-1.5 py-0.5 rounded border font-medium", tier_class]}>
+                    <%= tier_label %>
+                  </span>
+                </div>
+                <div class="text-right">
+                  <div class="text-sm text-gray-300">
+                    entry <%= format_price(pos["entry_price"]) %>
+                  </div>
+                  <div class="text-xs text-gray-600">
+                    stop <%= format_price(pos["stop_price"]) %>
+                    · <%= pos["entry_date"] %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+      <%# Watchlist %>
+      <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Watchlist (<%= length(@watchlist) %>)
+        </h2>
+        <%= if @watchlist == [] do %>
+          <p class="text-sm text-gray-600 italic">No watchlist items — screener may not have run yet</p>
+        <% else %>
+          <div class="space-y-1.5">
+            <%= for item <- @watchlist do %>
+              <% priority_class = case item["priority"] do
+                "strong_signal" -> "text-green-400"
+                "signal" -> "text-blue-400"
+                _ -> "text-gray-500"
+              end
+              {tier_label, tier_class} = tier_badge(item["tier"]) %>
+              <div class="flex items-center justify-between text-sm">
+                <div class="flex items-center gap-2">
+                  <span class="font-mono font-semibold text-white w-16"><%= item["symbol"] %></span>
+                  <span class={["text-xs px-1.5 py-0.5 rounded border font-medium", tier_class]}>
+                    <%= tier_label %>
+                  </span>
+                  <span class={["text-xs font-medium", priority_class]}>
+                    <%= item["priority"] %>
+                  </span>
+                </div>
+                <div class="text-right text-gray-400 text-xs">
+                  RSI-2 <%= format_float(item["rsi2"]) %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%# ── Right: Live Signal Feed ── %>
+    <div class="space-y-4">
+
+      <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Live Signal Feed
+        </h2>
+        <%= if @live_signals == [] do %>
+          <p class="text-sm text-gray-600 italic">Waiting for signals...</p>
+        <% else %>
+          <div class="space-y-1.5 max-h-96 overflow-y-auto">
+            <%= for sig <- @live_signals do %>
+              <div class="flex items-start gap-2 py-1.5 border-b border-gray-700/40 last:border-0">
+                <span class="text-base leading-none mt-0.5"><%= signal_icon(sig) %></span>
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2">
+                    <span class="font-mono font-semibold text-white text-sm">
+                      <%= sig["symbol"] %>
+                    </span>
+                    <span class="text-xs text-gray-500"><%= signal_time(sig) %></span>
+                  </div>
+                  <div class="text-xs text-gray-400 truncate">
+                    <%= signal_detail(sig) %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+      <%# Daily Summaries %>
+      <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
+        <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+          Daily Performance (Last 7 Days)
+        </h2>
+        <%= if @daily_summaries == [] do %>
+          <p class="text-sm text-gray-600 italic">No daily summaries yet</p>
+        <% else %>
+          <table class="w-full text-xs">
+            <thead>
+              <tr class="text-gray-500">
+                <th class="text-left pb-1.5">Date</th>
+                <th class="text-right pb-1.5">P&L</th>
+                <th class="text-right pb-1.5">P&L %</th>
+                <th class="text-right pb-1.5">Trades</th>
+                <th class="text-right pb-1.5">W/L</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-700/30">
+              <%= for day <- @daily_summaries do %>
+                <% pnl_val = Decimal.to_float(day.daily_pnl)
+                   pnl_pct = Decimal.to_float(day.daily_pnl_pct) %>
+                <tr>
+                  <td class="py-1 text-gray-300"><%= Calendar.strftime(day.date, "%b %d") %></td>
+                  <td class={["py-1 text-right font-mono", pnl_class(pnl_val)]}>
+                    <%= format_signed_pct(pnl_val) |> String.replace("%", "") |> then(&"$#{&1}") %>
+                  </td>
+                  <td class={["py-1 text-right font-mono", pnl_class(pnl_pct)]}>
+                    <%= format_signed_pct(pnl_pct) %>
+                  </td>
+                  <td class="py-1 text-right text-gray-400"><%= day.trades_executed %></td>
+                  <td class="py-1 text-right">
+                    <span class="text-green-400"><%= day.winning_trades %></span>
+                    <span class="text-gray-600">/</span>
+                    <span class="text-red-400"><%= day.losing_trades %></span>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <%# ── Recent Trades Table ─────────────────────────────────────── %>
+  <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
+    <h2 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+      Recent Trades
+    </h2>
+    <%= if @recent_trades == [] do %>
+      <p class="text-sm text-gray-600 italic">No trades yet</p>
+    <% else %>
+      <div class="overflow-x-auto">
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="text-gray-500 border-b border-gray-700">
+              <th class="text-left pb-2">Time</th>
+              <th class="text-left pb-2">Symbol</th>
+              <th class="text-left pb-2">Side</th>
+              <th class="text-right pb-2">Qty</th>
+              <th class="text-right pb-2">Price</th>
+              <th class="text-right pb-2">Value</th>
+              <th class="text-right pb-2">P&L</th>
+              <th class="text-left pb-2 hidden sm:table-cell">Strategy</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-700/30">
+            <%= for trade <- @recent_trades do %>
+              <tr class="hover:bg-gray-700/20 transition-colors">
+                <td class="py-1.5 text-gray-500 whitespace-nowrap">
+                  <%= Calendar.strftime(trade.time, "%b %d %-I:%M%p") %>
+                </td>
+                <td class="py-1.5 font-mono font-semibold text-white">
+                  <%= trade.symbol %>
+                </td>
+                <td class={["py-1.5 font-medium uppercase", if(trade.side == "buy", do: "text-blue-400", else: "text-orange-400")]}>
+                  <%= trade.side %>
+                </td>
+                <td class="py-1.5 text-right text-gray-300 font-mono">
+                  <%= Decimal.round(trade.quantity, 4) %>
+                </td>
+                <td class="py-1.5 text-right text-gray-300 font-mono">
+                  $<%= Decimal.round(trade.price, 2) %>
+                </td>
+                <td class="py-1.5 text-right text-gray-300 font-mono">
+                  $<%= Decimal.round(trade.total_value, 2) %>
+                </td>
+                <td class="py-1.5 text-right font-mono">
+                  <%= if trade.realized_pnl do %>
+                    <span class={pnl_class(Decimal.to_float(trade.realized_pnl))}>
+                      $<%= Decimal.round(trade.realized_pnl, 2) %>
+                    </span>
+                  <% else %>
+                    <span class="text-gray-600">—</span>
+                  <% end %>
+                </td>
+                <td class="py-1.5 text-gray-500 hidden sm:table-cell">
+                  <%= trade.strategy %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </div>
+
+</div>

--- a/dashboard/lib/dashboard_web/router.ex
+++ b/dashboard/lib/dashboard_web/router.ex
@@ -1,0 +1,28 @@
+defmodule DashboardWeb.Router do
+  use DashboardWeb, :router
+
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {DashboardWeb.Layouts, :root}
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  pipeline :api do
+    plug :accepts, ["json"]
+  end
+
+  scope "/", DashboardWeb do
+    pipe_through :browser
+
+    live "/", DashboardLive, :index
+  end
+
+  # Health check endpoint — used by Docker healthcheck
+  scope "/health", DashboardWeb do
+    pipe_through :api
+    get "/", HealthController, :index
+  end
+end

--- a/dashboard/lib/dashboard_web/telemetry.ex
+++ b/dashboard/lib/dashboard_web/telemetry.ex
@@ -1,0 +1,41 @@
+defmodule DashboardWeb.Telemetry do
+  use Supervisor
+  import Telemetry.Metrics
+
+  def start_link(arg) do
+    Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_arg) do
+    children = [
+      {:telemetry_poller, measurements: periodic_measurements(), period: 10_000}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  def metrics do
+    [
+      # Phoenix Metrics
+      summary("phoenix.endpoint.start.system_time", unit: {:native, :millisecond}),
+      summary("phoenix.endpoint.stop.duration", unit: {:native, :millisecond}),
+      summary("phoenix.router_dispatch.stop.duration",
+        tags: [:route],
+        unit: {:native, :millisecond}
+      ),
+
+      # Database Metrics
+      summary("dashboard.repo.query.total_time", unit: {:native, :millisecond}),
+
+      # VM Metrics
+      summary("vm.memory.total", unit: {:byte, :kilobyte}),
+      summary("vm.total_run_queue_lengths.total"),
+      summary("vm.total_run_queue_lengths.cpu")
+    ]
+  end
+
+  defp periodic_measurements do
+    []
+  end
+end

--- a/dashboard/mix.exs
+++ b/dashboard/mix.exs
@@ -1,0 +1,79 @@
+defmodule Dashboard.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :dashboard,
+      version: "1.0.0",
+      elixir: "~> 1.17",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {Dashboard.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
+  defp deps do
+    [
+      # Phoenix
+      {:phoenix, "~> 1.7"},
+      {:phoenix_html, "~> 4.1"},
+      {:phoenix_live_view, "~> 1.0"},
+      {:phoenix_live_reload, "~> 1.2", only: :dev},
+
+      # HTTP server
+      {:bandit, "~> 1.5"},
+
+      # Database
+      {:ecto_sql, "~> 3.12"},
+      {:postgrex, ">= 0.0.0"},
+      {:phoenix_ecto, "~> 4.6"},
+
+      # Redis
+      {:redix, "~> 1.5"},
+
+      # HTTP client (Alpaca market clock)
+      {:req, "~> 0.5"},
+
+      # JSON
+      {:jason, "~> 1.4"},
+
+      # Observability
+      {:telemetry_metrics, "~> 1.0"},
+      {:telemetry_poller, "~> 1.0"},
+
+      # Assets
+      {:tailwind, "~> 0.2", runtime: Mix.env() == :dev},
+      {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
+
+      # Code quality (dev/test only)
+      {:floki, ">= 0.30.0", only: :test}
+    ]
+  end
+
+  defp aliases do
+    [
+      setup: ["deps.get", "ecto.setup", "assets.setup", "assets.build"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.reset": ["ecto.drop", "ecto.setup"],
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
+      "assets.build": ["tailwind dashboard", "esbuild dashboard"],
+      "assets.deploy": [
+        "tailwind dashboard --minify",
+        "esbuild dashboard --minify",
+        "phx.digest"
+      ]
+    ]
+  end
+end

--- a/dashboard/priv/static/robots.txt
+++ b/dashboard/priv/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 # docker-compose.yml
-# Trading system infrastructure: Redis (shared state) + TimescaleDB (historical storage)
+# Trading system infrastructure: Redis, TimescaleDB, and Phoenix LiveView dashboard
 # Place this in ~/trading-system/ on your VPS
+#
+# Dashboard access: served via Tailscale — run once on the host after first `docker compose up`:
+#   tailscale serve https / http://localhost:4000
+# Then access at https://openboog.<tailnet>.ts.net from any device on your tailnet.
 
 services:
   redis:
@@ -41,6 +45,42 @@ services:
       interval: 10s
       timeout: 3s
       retries: 3
+
+  dashboard:
+    build:
+      context: ./dashboard
+      dockerfile: Dockerfile
+    container_name: trading_dashboard
+    restart: unless-stopped
+    ports:
+      # Bound to loopback only — Tailscale serve proxies from outside
+      - "127.0.0.1:4000:4000"
+    environment:
+      # Phoenix runtime
+      PHX_SERVER: "true"
+      PORT: "4000"
+      # Set to your Tailscale hostname: run `tailscale status` to find it
+      # e.g. openboog.tail1234.ts.net or just openboog if MagicDNS is enabled
+      PHX_HOST: "${TAILSCALE_HOSTNAME:-localhost}"
+      SECRET_KEY_BASE: "${DASHBOARD_SECRET_KEY_BASE}"
+      # Database — uses Docker service name, not localhost
+      DATABASE_URL: "ecto://trader:${TSDB_PASSWORD:-changeme_in_env_file}@timescaledb:5432/trading"
+      # Redis — uses Docker service name, not localhost
+      REDIS_URL: "redis://redis:6379"
+      # Alpaca (for market clock and account data)
+      ALPACA_API_KEY: "${ALPACA_API_KEY}"
+      ALPACA_SECRET_KEY: "${ALPACA_SECRET_KEY}"
+    depends_on:
+      redis:
+        condition: service_healthy
+      timescaledb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
 volumes:
   redis_data:


### PR DESCRIPTION
## Summary

- Full Phoenix 1.7 + LiveView 1.0 application in `dashboard/`
- **RedisPoller** GenServer polls all 15 Redis keys every 2s via pipelined MGET, broadcasts to PubSub
- **RedisSubscriber** subscribes to `trading:signals` pub/sub for real-time signal feed
- **MarketClock** polls Alpaca `/v2/clock` every 30s for market open/closed status
- Read-only Ecto schemas (`Trade`, `Signal`, `Position`, `DailySummary`) against existing TimescaleDB
- Single-page LiveView with dark terminal aesthetic (Tailwind CSS):
  - Key metrics: equity, daily P&L, drawdown, PDT count, regime, risk multiplier
  - Agent heartbeat status (green/yellow/red by staleness)
  - Open positions and watchlist from Redis
  - Live signal feed (real-time via pub/sub, newest-first)
  - Daily performance table (last 7 days from TimescaleDB)
  - Recent trades table (last 15 from TimescaleDB)
- `/health` JSON endpoint for Docker healthcheck
- Multi-stage Dockerfile: `elixir:1.18-otp-27-alpine` builder → `ubuntu:24.04` runtime
- `docker-compose.yml` dashboard service with Tailscale hostname env var

## Test plan

- [ ] Run `cd dashboard && mix deps.get && mix compile` — should compile clean
- [ ] Run `docker compose up --build dashboard` on openboog — should build and start
- [ ] Run `tailscale serve https / http://localhost:4000` once on openboog
- [ ] Open `https://openboog.<tailnet>.ts.net` — should show dashboard
- [ ] Verify Redis metrics update every 2s (equity, status, heartbeats)
- [ ] Verify live signals appear when screener/watcher run
- [ ] Verify `/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)