### PR TITLE
auto-load ~/.trading_env in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,13 @@
 #   tailscale serve https / http://localhost:4000
 # Then access at https://openboog.<tailnet>.ts.net from any device on your tailnet.
 
+# Load variables from ~/.trading_env for ${VAR} interpolation throughout this file.
+# Docker Compose strips `export` and quotes automatically.
+# required: false so this works on dev machines without the file.
+env_file:
+  - path: ~/.trading_env
+    required: false
+
 services:
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary

- Adds a top-level `env_file` to `docker-compose.yml` pointing at `~/.trading_env`
- Docker Compose v2 supports this natively — it strips `export` and quotes, making all vars available for `${VAR}` interpolation throughout the file
- `required: false` so it silently no-ops on machines without the file
- Eliminates the need to `source ~/.trading_env` before every `docker compose up`

## Test plan

- [ ] Run `docker compose up --build -d` on openboog without sourcing env first — no warnings about missing vars
- [ ] Confirm `DASHBOARD_SECRET_KEY_BASE` is set in `~/.trading_env` first (`openssl rand -base64 48`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)