### PR TITLE
replace env_file compose key with .env generation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,6 @@
 #   tailscale serve https / http://localhost:4000
 # Then access at https://openboog.<tailnet>.ts.net from any device on your tailnet.
 
-# Load variables from ~/.trading_env for ${VAR} interpolation throughout this file.
-# Docker Compose strips `export` and quotes automatically.
-# required: false so this works on dev machines without the file.
-env_file:
-  - path: ~/.trading_env
-    required: false
-
 services:
   redis:
     image: redis:7-alpine

--- a/start_trading_system.sh
+++ b/start_trading_system.sh
@@ -74,6 +74,21 @@ check_env() {
     if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
         log_warn "Telegram not configured — notifications will print to console only"
     fi
+
+    sync_docker_env
+}
+
+sync_docker_env() {
+    # Generate ~/trading-system/.env from ~/.trading_env so that
+    # `docker compose` picks up all variables without needing a manual `source`.
+    # .env is gitignored — never committed.
+    # Strips `export ` prefix; keeps quoted values as-is (Compose handles them).
+    local dot_env="${TRADING_DIR}/.env"
+    grep -E '^export [A-Z_]+=' "$ENV_FILE" \
+        | sed 's/^export //' \
+        > "$dot_env"
+    chmod 600 "$dot_env"
+    log_info "Synced ${ENV_FILE} → ${dot_env}"
 }
 
 check_infrastructure() {


### PR DESCRIPTION
## Summary

- Removes the top-level `env_file` key from `docker-compose.yml` — it requires Docker Compose v2.24+ and fails validation on the version installed on openboog
- Instead, `start_trading_system.sh` now calls `sync_docker_env()` at the end of `check_env()`, which generates `~/trading-system/.env` by stripping `export ` from `~/.trading_env`
- Docker Compose has auto-read `.env` from the project directory since v1 — no version dependency
- `.env` is already gitignored; it's regenerated on every `./start_trading_system.sh` run so it stays in sync

## Test plan

- [ ] Run `./start_trading_system.sh` on openboog — should log "Synced ~/.trading_env → .env"
- [ ] Run `docker compose up --build -d` — no warnings about missing vars
- [ ] Confirm `.env` is not tracked by git (`git status` shows nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)