### PR TITLE
fix Dockerfile layer order for mix assets.deploy

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -24,17 +24,26 @@ RUN mix local.hex --force && mix local.rebar --force
 # If mix.lock doesn't exist yet, `mix deps.get` creates it.
 COPY mix.exs ./
 COPY mix.lock* ./
+
+# Copy compile-time config before deps.compile so config changes
+# correctly bust the deps layer cache.
+COPY config/config.exs config/prod.exs config/
+
 RUN mix deps.get --only prod
 RUN mix deps.compile
+
+# Copy lib before assets so tailwind can scan .heex/.ex files for class names
+COPY lib lib
 
 # Build assets (Tailwind + esbuild)
 COPY assets assets
 COPY priv priv
 RUN mix assets.deploy
 
+# Copy runtime config last — changes here don't require recompiling deps or assets
+COPY config/runtime.exs config/
+
 # Compile app and create release
-COPY lib lib
-COPY config config
 RUN mix compile
 RUN mix release
 


### PR DESCRIPTION
## Summary

`mix assets.deploy` was failing with exit code 1 because the `config/` directory wasn't present when it ran — tailwind and esbuild read their version pins and input/output paths from `config/config.exs` and `config/prod.exs`. Additionally, `lib/` wasn't present so tailwind had no templates to scan for Tailwind class names.

Reordered to match the standard `mix phx.gen.release` Dockerfile pattern:

1. Copy `config/config.exs` + `config/prod.exs` **before** `mix deps.compile` (config changes bust deps cache correctly)
2. Copy `lib/` **before** assets (tailwind scans `.heex`/`.ex` files for class names)
3. `mix assets.deploy`
4. Copy `config/runtime.exs` **last** (runtime-only, no recompile needed when it changes)
5. `mix compile` + `mix release`

## Test plan

- [ ] `docker compose up --build -d` completes without error
- [ ] Dashboard is reachable at `http://localhost:4000/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)