### PR TITLE
fix phoenix_html v4 incompatibility in dashboard_web.ex

### DIFF
--- a/dashboard/lib/dashboard_web.ex
+++ b/dashboard/lib/dashboard_web.ex
@@ -60,8 +60,7 @@ defmodule DashboardWeb do
 
   defp html_helpers do
     quote do
-      use Phoenix.HTML
-      import Phoenix.LiveView.Helpers
+      import Phoenix.HTML
       import DashboardWeb.CoreComponents
       unquote(verified_routes())
     end


### PR DESCRIPTION
## Summary

Two compilation errors from library version mismatches:

1. **`use Phoenix.HTML` removed in phoenix_html v4.0** — changed to `import Phoenix.HTML`. The `use` macro was dropped; importing the module directly is the supported path.

2. **`Phoenix.LiveView.Helpers` removed in LiveView 1.0** — removed the import entirely. Those helpers moved into `Phoenix.Component`, which is already in scope via `use Phoenix.LiveView` and `use Phoenix.Component`.

## Test plan

- [ ] `docker compose up --build -d` completes without compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)