### PR TITLE
serve dashboard on port 4000, leave 443 for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ redis-cli ping
 
 Redis runs on port 6379, TimescaleDB on port 5432. The database schema is automatically created on first startup via `init-db/001_create_schema.sql`.
 
+### Tailscale Setup
+
+The dashboard is served at **port 4000** on your tailnet, leaving port 443 free for OpenClaw. Run these once on the VPS:
+
+```bash
+# Serve dashboard at https://openboog.tail233812.ts.net:4000
+sudo tailscale serve --bg --https=4000 http://localhost:4000
+
+# OpenClaw stays on the default port (replace 3000 with OpenClaw's local port)
+sudo tailscale serve --bg --https=443 http://localhost:3000
+
+# Verify both are configured
+tailscale serve status
+```
+
+Dashboard URL: `https://<your-tailnet-hostname>:4000`
+
 ### Telegram Notifications (Optional)
 
 1. Open Telegram, search for `@BotFather`

--- a/dashboard/config/runtime.exs
+++ b/dashboard/config/runtime.exs
@@ -23,7 +23,9 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :dashboard, DashboardWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    # Dashboard is served at :4000 via `tailscale serve --https=4000 http://localhost:4000`
+    # Port 443 is reserved for OpenClaw on the same tailnet hostname.
+    url: [host: host, port: 4000, scheme: "https"],
     http: [
       ip: {0, 0, 0, 0},
       port: port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,10 @@
 # Trading system infrastructure: Redis, TimescaleDB, and Phoenix LiveView dashboard
 # Place this in ~/trading-system/ on your VPS
 #
-# Dashboard access: served via Tailscale — run once on the host after first `docker compose up`:
-#   tailscale serve https / http://localhost:4000
-# Then access at https://openboog.<tailnet>.ts.net from any device on your tailnet.
+# Dashboard access: served via Tailscale on port 4000 (443 is reserved for OpenClaw).
+# Run once on the host after first `docker compose up`:
+#   sudo tailscale serve --bg --https=4000 http://localhost:4000
+# Then access at https://openboog.<tailnet>.ts.net:4000 from any device on your tailnet.
 
 # Load variables from ~/.trading_env for ${VAR} interpolation throughout this file.
 # Docker Compose strips `export` and quotes automatically.


### PR DESCRIPTION
## Summary

Port 443 on the tailnet was already in use by OpenClaw. Dashboard moves to `:4000`:

- **`runtime.exs`**: `url` port `443` → `4000` so Phoenix generates correct URLs and LiveView WebSocket connects to the right place
- **`docker-compose.yml`**: comment updated with correct `tailscale serve` command
- **README**: new **Tailscale Setup** section with both commands side by side

## Commands to run on openboog (once)

```bash
# Remove dashboard from 443 (already done)
sudo tailscale serve --https=443 off

# Restore OpenClaw on 443 (replace 3000 with OpenClaw's local port)
sudo tailscale serve --bg --https=443 http://localhost:3000

# Dashboard on 4000
sudo tailscale serve --bg --https=4000 http://localhost:4000
```

## Test plan

- [ ] `tailscale serve status` shows both 443 → OpenClaw and 4000 → dashboard
- [ ] OpenClaw accessible at `https://openboog.tail233812.ts.net`
- [ ] Dashboard accessible at `https://openboog.tail233812.ts.net:4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)