### PR TITLE
switch Dockerfile builder from Alpine to Debian

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,14 +7,16 @@
 # Build is triggered automatically by `docker compose up --build`.
 
 # ── Stage 1: Builder ────────────────────────────────────────────────────────
-FROM elixir:1.18-otp-27-alpine AS builder
+FROM elixir:1.18-otp-27 AS builder
 
 WORKDIR /app
 
 ENV MIX_ENV=prod
 
-# Build tools
-RUN apk add --no-cache build-base git nodejs npm
+# Build tools (Debian-based image — same glibc as the ubuntu:24.04 runtime)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
 
 # Hex + rebar
 RUN mix local.hex --force && mix local.rebar --force


### PR DESCRIPTION
## Summary

The Alpine-based builder (`elixir:1.18-otp-27-alpine`) uses musl libc. The Mix release bundles ERTS (the Erlang runtime) compiled against musl, but the runtime image is `ubuntu:24.04` which uses glibc. The two are ABI-incompatible, causing:

```
/app/erts-15.2.7.6/bin/erlexec: not found
```

Fix: switch the builder to `elixir:1.18-otp-27` (Debian bookworm, glibc). The bundled ERTS is now compiled against glibc and runs cleanly on ubuntu:24.04. Updated `apk` → `apt-get` for build tool installation.

## Test plan

- [ ] `docker compose up --build -d` completes
- [ ] `docker compose logs dashboard` shows Phoenix starting, not an erlexec error
- [ ] `https://openboog.tail233812.ts.net:4000` returns the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)