### PR TITLE
fix two dashboard startup crashes

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -53,12 +53,18 @@ RUN mix release
 FROM ubuntu:24.04 AS runtime
 
 # Runtime deps only (no build tools)
+# locales required so Erlang/Elixir use UTF-8 name encoding, not latin1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     libncurses6 \
     libstdc++6 \
     curl \
+    locales \
+    && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 WORKDIR /app
 

--- a/dashboard/lib/dashboard/application.ex
+++ b/dashboard/lib/dashboard/application.ex
@@ -17,11 +17,11 @@ defmodule Dashboard.Application do
       # PubSub — used by LiveView and background processes
       {Phoenix.PubSub, name: Dashboard.PubSub},
 
-      # Redis connections
+      # Redis connections — explicit IDs required when starting the same module twice
       # One connection for GET/MGET polling
-      {Redix, {redis_url, [name: :redix]}},
+      Supervisor.child_spec({Redix, {redis_url, [name: :redix]}}, id: :redix),
       # One connection dedicated to pub/sub (blocked while subscribed)
-      {Redix, {redis_url, [name: :redix_pubsub]}},
+      Supervisor.child_spec({Redix, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
 
       # Background GenServers
       Dashboard.RedisPoller,


### PR DESCRIPTION
## Summary

Two bugs causing the dashboard container to crash immediately on start:

### 1. Duplicate Redix supervisor child ID
Starting `Redix` twice without explicit IDs means both children get the default ID `Elixir.Redix`. The OTP supervisor rejects duplicate IDs:
```
bad child specification, more than one child specification has the id: Redix
```
Fixed with `Supervisor.child_spec/2`:
```elixir
Supervisor.child_spec({Redix, {redis_url, [name: :redix]}}, id: :redix),
Supervisor.child_spec({Redix, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
```

### 2. Latin1 locale → Erlang crash
`ubuntu:24.04` has no UTF-8 locale by default. Erlang starts with latin1 name encoding, which Elixir refuses to run under:
```
warning: the VM is running with native name encoding of latin1
```
Fixed by installing `locales`, generating `en_US.UTF-8`, and setting `LANG`/`LC_ALL` in the runtime stage.

## Test plan

- [ ] `docker compose up --build -d` completes
- [ ] `docker compose logs dashboard` shows Phoenix endpoint accepting connections, no crash
- [ ] Dashboard loads at `https://openboog.tail233812.ts.net:4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)