### PR TITLE
handle Postgrex TypeServer crash on TimescaleDB startup

### DIFF
--- a/dashboard/config/runtime.exs
+++ b/dashboard/config/runtime.exs
@@ -11,8 +11,13 @@ if config_env() == :prod do
 
   config :dashboard, Dashboard.Repo,
     url: database_url,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
-    # TimescaleDB lives on the same Docker network — use service name
+    # Small pool — this is a read-only dashboard, not a write-heavy app
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "2"),
+    # Give the Postgrex TypeServer time to initialize before connections
+    # pile in — helps with TimescaleDB's large custom type catalogue
+    queue_target: 5_000,
+    queue_interval: 10_000,
+    connect_timeout: 30_000,
     socket_options: []
 
   secret_key_base =

--- a/dashboard/lib/dashboard/queries.ex
+++ b/dashboard/lib/dashboard/queries.ex
@@ -2,6 +2,11 @@ defmodule Dashboard.Queries do
   @moduledoc """
   Query helpers for the trading dashboard.
   All queries are read-only — the dashboard never writes to the database.
+
+  Every public function is wrapped in rescue so a DB outage (including
+  Postgrex TypeServer startup races with TimescaleDB) returns empty data
+  rather than crashing the LiveView. The live Redis feed continues to work
+  regardless of DB availability.
   """
 
   import Ecto.Query
@@ -10,47 +15,71 @@ defmodule Dashboard.Queries do
 
   @doc "Recent trades for the trades table."
   def recent_trades(limit \\ 20) do
-    Trade.recent(limit) |> Repo.all()
+    try do
+      Trade.recent(limit) |> Repo.all()
+    rescue
+      _ -> []
+    end
   end
 
   @doc "Recent signals from the signals table."
   def recent_signals(limit \\ 50) do
-    Signal.recent(limit) |> Repo.all()
+    try do
+      Signal.recent(limit) |> Repo.all()
+    rescue
+      _ -> []
+    end
   end
 
   @doc "Last N days of daily summaries."
   def daily_summaries(days \\ 14) do
-    DailySummary.recent(days) |> Repo.all()
+    try do
+      DailySummary.recent(days) |> Repo.all()
+    rescue
+      _ -> []
+    end
   end
 
   @doc "Currently open positions from the database."
   def open_positions do
-    Position.open() |> Repo.all()
+    try do
+      Position.open() |> Repo.all()
+    rescue
+      _ -> []
+    end
   end
 
   @doc "Aggregate win/loss stats over a date range."
   def win_loss_stats(days_back \\ 30) do
-    cutoff = Date.add(Date.utc_today(), -days_back)
+    try do
+      cutoff = Date.add(Date.utc_today(), -days_back)
 
-    from(s in DailySummary,
-      where: s.date >= ^cutoff,
-      select: %{
-        total_trades: sum(s.trades_executed),
-        winning_trades: sum(s.winning_trades),
-        losing_trades: sum(s.losing_trades),
-        total_pnl: sum(s.daily_pnl),
-        total_fees: sum(s.total_fees)
-      }
-    )
-    |> Repo.one()
+      from(s in DailySummary,
+        where: s.date >= ^cutoff,
+        select: %{
+          total_trades: sum(s.trades_executed),
+          winning_trades: sum(s.winning_trades),
+          losing_trades: sum(s.losing_trades),
+          total_pnl: sum(s.daily_pnl),
+          total_fees: sum(s.total_fees)
+        }
+      )
+      |> Repo.one()
+    rescue
+      _ -> nil
+    end
   end
 
   @doc "Total realized P&L from the trades table."
   def total_realized_pnl do
-    from(t in Trade,
-      where: t.side == "sell" and not is_nil(t.realized_pnl),
-      select: sum(t.realized_pnl)
-    )
-    |> Repo.one()
+    try do
+      from(t in Trade,
+        where: t.side == "sell" and not is_nil(t.realized_pnl),
+        select: sum(t.realized_pnl)
+      )
+      |> Repo.one()
+    rescue
+      _ -> nil
+    end
   end
 end


### PR DESCRIPTION
## Summary

TimescaleDB registers a large number of custom types in `pg_type`. When Postgrex bootstraps a new connection, it loads all these types then calls into the per-pool `TypeServer` process to register them. With the default pool size of 5, multiple connections race to register types simultaneously, overloading the TypeServer and causing it to die — which crashes `Dashboard.Application`.

Two fixes:

**1. Defensive queries (`queries.ex`)** — every `Repo` call is wrapped in `rescue` and returns empty data on failure. The dashboard's live Redis feed (positions, signals, heartbeats, equity) continues to work regardless of DB state. The trades and daily summary tables just show "no data yet" until DB recovers.

**2. Serialize pool startup (`runtime.exs`)** — `pool_size: 2` (down from 5), `queue_target: 5_000`, `queue_interval: 10_000`, `connect_timeout: 30_000` — gives the TypeServer time to process one connection's types before the next one arrives.

## Test plan

- [ ] `docker compose up --build -d` — dashboard starts without crashing
- [ ] `docker compose logs dashboard` — Phoenix endpoint comes up, no TypeServer error
- [ ] Dashboard loads at `:4000` — Redis widgets show live data even if DB section shows "no data yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)