### PR TITLE
fix RedisSubscriber crash: start pubsub conn as Redix.PubSub

### DIFF
--- a/dashboard/lib/dashboard/application.ex
+++ b/dashboard/lib/dashboard/application.ex
@@ -20,8 +20,8 @@ defmodule Dashboard.Application do
       # Redis connections — explicit IDs required when starting the same module twice
       # One connection for GET/MGET polling
       Supervisor.child_spec({Redix, {redis_url, [name: :redix]}}, id: :redix),
-      # One connection dedicated to pub/sub (blocked while subscribed)
-      Supervisor.child_spec({Redix, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
+      # One connection dedicated to pub/sub — must be Redix.PubSub, not Redix
+      Supervisor.child_spec({Redix.PubSub, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
 
       # Background GenServers
       Dashboard.RedisPoller,


### PR DESCRIPTION
## Summary

`Dashboard.RedisSubscriber` was crashing immediately at startup, killing the whole application:

```
failed_to_start_child, 'Elixir.Dashboard.RedisSubscriber',
  function_clause, 'Elixir.Redix.Connection', connecting, subscribe
```

Root cause: `:redix_pubsub` was started as `{Redix, ...}` — a plain command connection. `RedisSubscriber.init/1` then called `Redix.PubSub.subscribe(:redix_pubsub, "trading:signals", self())` on it. `Redix.Connection` has no clause for `subscribe` messages, so it raised `function_clause`, crashing the child, which propagated up through the supervisor and killed `Dashboard.Application`.

Fix: change the child spec to `{Redix.PubSub, ...}` so the connection accepts subscribe/unsubscribe commands and delivers `{:redix_pubsub, pid, ref, :message, %{...}}` messages to subscriber processes — exactly the format `RedisSubscriber` expects.

## Test plan

- [ ] `docker compose up --build -d`
- [ ] `docker compose logs dashboard` — no `function_clause` or `failed_to_start_child` error
- [ ] Phoenix endpoint comes up and dashboard loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)