### PR TITLE
fix pub/sub: Redix.PubSub removed in Redix 1.0

### DIFF
--- a/dashboard/lib/dashboard/application.ex
+++ b/dashboard/lib/dashboard/application.ex
@@ -20,8 +20,9 @@ defmodule Dashboard.Application do
       # Redis connections — explicit IDs required when starting the same module twice
       # One connection for GET/MGET polling
       Supervisor.child_spec({Redix, {redis_url, [name: :redix]}}, id: :redix),
-      # One connection dedicated to pub/sub — must be Redix.PubSub, not Redix
-      Supervisor.child_spec({Redix.PubSub, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
+      # Dedicated connection for pub/sub — stays in subscriber mode once subscribed
+      # Redix.PubSub was removed in Redix 1.0; use plain Redix with Redix.subscribe/3
+      Supervisor.child_spec({Redix, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
 
       # Background GenServers
       Dashboard.RedisPoller,

--- a/dashboard/lib/dashboard/redis_subscriber.ex
+++ b/dashboard/lib/dashboard/redis_subscriber.ex
@@ -5,6 +5,10 @@ defmodule Dashboard.RedisSubscriber do
   Whenever the Watcher publishes a signal, this process receives it and
   broadcasts it to the PubSub topic "dashboard:signals" so the LiveView
   can update the live signal feed without waiting for the next poll cycle.
+
+  Note: Redix.PubSub was removed in Redix 1.0. Pub/sub is now done through
+  plain Redix connections via Redix.subscribe/3. The message format is
+  identical: {:redix_pubsub, pid, ref, type, info}.
   """
 
   use GenServer
@@ -18,22 +22,20 @@ defmodule Dashboard.RedisSubscriber do
 
   @impl true
   def init(state) do
-    # Subscribe using the dedicated pubsub connection
-    case Redix.PubSub.subscribe(:redix_pubsub, @channel, self()) do
+    case Redix.subscribe(:redix_pubsub, @channel, self()) do
       {:ok, _ref} ->
         Logger.info("RedisSubscriber: subscribed to #{@channel}")
         {:ok, state}
 
       {:error, reason} ->
         Logger.error("RedisSubscriber: subscribe failed: #{inspect(reason)}")
-        # Retry after 5 seconds
         Process.send_after(self(), :retry_subscribe, 5_000)
         {:ok, state}
     end
   end
 
   @impl true
-  def handle_info({:redix_pubsub, _client, _ref, :subscribed, %{channel: ch}}, state) do
+  def handle_info({:redix_pubsub, _client, _ref, :subscribe, %{channel: ch}}, state) do
     Logger.info("RedisSubscriber: confirmed subscription to #{ch}")
     {:noreply, state}
   end
@@ -60,7 +62,7 @@ defmodule Dashboard.RedisSubscriber do
   end
 
   def handle_info(:retry_subscribe, state) do
-    case Redix.PubSub.subscribe(:redix_pubsub, @channel, self()) do
+    case Redix.subscribe(:redix_pubsub, @channel, self()) do
       {:ok, _ref} ->
         Logger.info("RedisSubscriber: re-subscribed to #{@channel}")
 


### PR DESCRIPTION
## Summary

`Redix.PubSub` was a separate module in Redix 0.x but was removed entirely in Redix 1.0. In Redix 1.x, pub/sub is done through plain `Redix` connections using `Redix.subscribe/3`. The `{:redix_pubsub, pid, ref, type, info}` message format is unchanged.

Changes:
- **`application.ex`**: revert `:redix_pubsub` child back to `{Redix, ...}` (plain connection, not the removed `Redix.PubSub`)
- **`redis_subscriber.ex`**: replace `Redix.PubSub.subscribe` with `Redix.subscribe` in both `init/1` and the retry handler; update `:subscribed` → `:subscribe` to match the Redix 1.x message atom

## Test plan

- [ ] `docker compose up --build -d` — no `child_spec/1` error at startup
- [ ] `docker compose logs dashboard` — `RedisSubscriber: subscribed to trading:signals` appears
- [ ] Watcher signals appear in the live feed on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)