### PR TITLE
fix Redix.PubSub child spec and make Repo restart: :temporary

### DIFF
--- a/dashboard/lib/dashboard/application.ex
+++ b/dashboard/lib/dashboard/application.ex
@@ -11,8 +11,9 @@ defmodule Dashboard.Application do
       # Telemetry
       DashboardWeb.Telemetry,
 
-      # Database
-      Dashboard.Repo,
+      # Database — restart: :temporary so a Postgrex crash doesn't kill the whole app.
+      # Queries are wrapped in rescue, so the dashboard keeps running on DB failure.
+      Supervisor.child_spec(Dashboard.Repo, restart: :temporary),
 
       # PubSub — used by LiveView and background processes
       {Phoenix.PubSub, name: Dashboard.PubSub},
@@ -20,9 +21,15 @@ defmodule Dashboard.Application do
       # Redis connections — explicit IDs required when starting the same module twice
       # One connection for GET/MGET polling
       Supervisor.child_spec({Redix, {redis_url, [name: :redix]}}, id: :redix),
-      # Dedicated connection for pub/sub — stays in subscriber mode once subscribed
-      # Redix.PubSub was removed in Redix 1.0; use plain Redix with Redix.subscribe/3
-      Supervisor.child_spec({Redix, {redis_url, [name: :redix_pubsub]}}, id: :redix_pubsub),
+      # Dedicated pub/sub connection — Redix.PubSub doesn't implement child_spec/1
+      # so we provide the full map spec and call Redix.PubSub.subscribe/3 on it
+      %{
+        id: :redix_pubsub,
+        start: {Redix.PubSub, :start_link, [redis_url, [name: :redix_pubsub]]},
+        type: :worker,
+        restart: :permanent,
+        shutdown: 5_000
+      },
 
       # Background GenServers
       Dashboard.RedisPoller,

--- a/dashboard/lib/dashboard/redis_subscriber.ex
+++ b/dashboard/lib/dashboard/redis_subscriber.ex
@@ -6,9 +6,9 @@ defmodule Dashboard.RedisSubscriber do
   broadcasts it to the PubSub topic "dashboard:signals" so the LiveView
   can update the live signal feed without waiting for the next poll cycle.
 
-  Note: Redix.PubSub was removed in Redix 1.0. Pub/sub is now done through
-  plain Redix connections via Redix.subscribe/3. The message format is
-  identical: {:redix_pubsub, pid, ref, type, info}.
+  Redix.PubSub exists in Redix 1.x but doesn't implement child_spec/1,
+  so it must be started with a manual map child spec in application.ex.
+  Once started, Redix.PubSub.subscribe/3 works as expected.
   """
 
   use GenServer
@@ -22,7 +22,7 @@ defmodule Dashboard.RedisSubscriber do
 
   @impl true
   def init(state) do
-    case Redix.subscribe(:redix_pubsub, @channel, self()) do
+    case Redix.PubSub.subscribe(:redix_pubsub, @channel, self()) do
       {:ok, _ref} ->
         Logger.info("RedisSubscriber: subscribed to #{@channel}")
         {:ok, state}
@@ -62,7 +62,7 @@ defmodule Dashboard.RedisSubscriber do
   end
 
   def handle_info(:retry_subscribe, state) do
-    case Redix.subscribe(:redix_pubsub, @channel, self()) do
+    case Redix.PubSub.subscribe(:redix_pubsub, @channel, self()) do
       {:ok, _ref} ->
         Logger.info("RedisSubscriber: re-subscribed to #{@channel}")
 


### PR DESCRIPTION
## Summary

Two crashes, two fixes:

### 1. `Redix.PubSub` has no `child_spec/1`
`Redix.PubSub` exists in Redix 1.5.3 but doesn't implement `child_spec/1`, so it can't be passed directly to a supervisor (neither as `{Redix.PubSub, args}` nor via `Supervisor.child_spec/2`). Fix: provide a full map child spec:
```elixir
%{
  id: :redix_pubsub,
  start: {Redix.PubSub, :start_link, [redis_url, [name: :redix_pubsub]]},
  type: :worker,
  restart: :permanent,
  shutdown: 5_000
}
```
`Redix.PubSub.subscribe/3` is restored in `RedisSubscriber` (it exists and works once the connection is started correctly).

### 2. Postgrex 0.22.0 SCRAM.LockedCache ETS race
`Postgrex.SCRAM.LockedCache` writes to an ETS table during SCRAM auth. On repeated application restarts, the table's owner process gets recycled and the table is gone by the time a new connection tries to write to it. Fix: `restart: :temporary` on `Dashboard.Repo` so a Postgrex crash is contained — the supervisor and all other children (Redis, LiveView, endpoint) keep running. `Queries.ex` already wraps all DB calls in `rescue` so empty data is returned instead of crashing the LiveView.

## Test plan

- [ ] `docker compose up --build -d` — no `child_spec/1` or `subscribe` error
- [ ] `docker compose logs dashboard` shows `RedisSubscriber: subscribed to trading:signals`
- [ ] Phoenix endpoint starts and dashboard loads at `:4000`
- [ ] If Postgrex still errors, trades/summaries show "no data" but Redis widgets still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)