### PR TITLE
add castore dep and make MarketClock restart: :temporary

### DIFF
--- a/dashboard/lib/dashboard/application.ex
+++ b/dashboard/lib/dashboard/application.ex
@@ -34,7 +34,8 @@ defmodule Dashboard.Application do
       # Background GenServers
       Dashboard.RedisPoller,
       Dashboard.RedisSubscriber,
-      Dashboard.MarketClock,
+      # MarketClock is :temporary — Alpaca API failures must not crash the app
+      Supervisor.child_spec(Dashboard.MarketClock, restart: :temporary),
 
       # Phoenix endpoint (must be last)
       DashboardWeb.Endpoint

--- a/dashboard/lib/dashboard/market_clock.ex
+++ b/dashboard/lib/dashboard/market_clock.ex
@@ -77,6 +77,10 @@ defmodule Dashboard.MarketClock do
         {:error, reason} ->
           {:error, reason}
       end
+    rescue
+      e ->
+        {:error, Exception.message(e)}
+    end
     end
   end
 end

--- a/dashboard/mix.exs
+++ b/dashboard/mix.exs
@@ -44,6 +44,8 @@ defmodule Dashboard.MixProject do
 
       # HTTP client (Alpaca market clock)
       {:req, "~> 0.5"},
+      # CA certificate bundle — required by Req/Finch/Mint for HTTPS
+      {:castore, "~> 1.0"},
 
       # JSON
       {:jason, "~> 1.4"},


### PR DESCRIPTION
## Summary

`Dashboard.MarketClock` was crashing on every `:fetch` because `Req` → `Finch` → `Mint` requires a CA certificate bundle for HTTPS connections and none was available in the container. The GenServer crashed, restarted, crashed again, exhausted the supervisor's `max_restarts`, and shut down the entire application.

Three fixes:

- **`mix.exs`**: add `{:castore, "~> 1.0"}` — Mint automatically detects and uses this bundle for SSL certificate verification, no other config needed
- **`market_clock.ex`**: wrap `Req.get` in `rescue` so SSL/network errors return `{:error, message}` instead of raising and crashing the GenServer — the clock shows "UNKNOWN" gracefully
- **`application.ex`**: `restart: :temporary` for `MarketClock` — Alpaca API being unreachable must never bring down the trading dashboard

## Test plan

- [ ] `docker compose up --build -d` — app starts and stays up
- [ ] `docker compose logs dashboard` — no `castore` or MarketClock crash
- [ ] Dashboard loads; market status shows OPEN or CLOSED correctly
- [ ] If Alpaca creds are wrong/missing, market status shows UNKNOWN but dashboard still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)