### PR TITLE
enable Phoenix endpoint server via PHX_SERVER env var

### DIFF
--- a/dashboard/config/runtime.exs
+++ b/dashboard/config/runtime.exs
@@ -4,6 +4,11 @@ import Config
 # In Docker, these are injected by docker-compose.yml.
 # In dev, set them in config/dev.exs or your shell.
 
+# PHX_SERVER=true enables the HTTP listener — set in docker-compose.yml for prod
+if System.get_env("PHX_SERVER") do
+  config :dashboard, DashboardWeb.Endpoint, server: true
+end
+
 if config_env() == :prod do
   database_url =
     System.get_env("DATABASE_URL") ||


### PR DESCRIPTION
## Summary

`runtime.exs` never read the `PHX_SERVER` environment variable, so even though `docker-compose.yml` sets `PHX_SERVER=true`, the endpoint's `:server` option remained `false` and the HTTP listener never started:

```
Configuration :server was not enabled for DashboardWeb.Endpoint, http/https services won't start
```

Added the standard check from `mix phx.gen.release`:

```elixir
if System.get_env("PHX_SERVER") do
  config :dashboard, DashboardWeb.Endpoint, server: true
end
```

This is placed outside the `config_env() == :prod` block so it also works in any environment where `PHX_SERVER` is explicitly set.

## Test plan

- [ ] `docker compose up --build -d`
- [ ] `docker compose logs dashboard` — no "server was not enabled" message
- [ ] Dashboard loads at `https://openboog.tail233812.ts.net:4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)