### PR TITLE
fix embed_templates path in DashboardWeb.Layouts

### DIFF
--- a/dashboard/lib/dashboard_web/components/layouts.ex
+++ b/dashboard/lib/dashboard_web/components/layouts.ex
@@ -1,5 +1,5 @@
 defmodule DashboardWeb.Layouts do
   use DashboardWeb, :html
 
-  embed_templates "layouts/*"
+  embed_templates "../layouts/*"
 end


### PR DESCRIPTION
layouts.ex lives in components/ but templates are in layouts/; use relative path ../layouts/* so embed_templates resolves correctly.