### PR TITLE
disable LiveSocket origin check behind Tailscale proxy

### DIFF
--- a/dashboard/config/runtime.exs
+++ b/dashboard/config/runtime.exs
@@ -40,7 +40,10 @@ if config_env() == :prod do
       ip: {0, 0, 0, 0},
       port: port
     ],
-    secret_key_base: secret_key_base
+    secret_key_base: secret_key_base,
+    # Tailscale terminates TLS and proxies to localhost — disable Phoenix's
+    # origin check since Tailscale already enforces network-level auth.
+    check_origin: false
 end
 
 # Redis URL — used by RedisPoller and RedisSubscriber


### PR DESCRIPTION
Phoenix rejects WebSocket upgrades when the Origin header (https://openboog.tail233812.ts.net:4000) doesn't match the configured url host, causing LiveView to loop on longpoll forever. Tailscale handles network-level auth, so check_origin: false is safe.