### PR TITLE
fix notification timestamps to use America/New_York in 24h format

### DIFF
--- a/scripts/discover_universe.py
+++ b/scripts/discover_universe.py
@@ -46,7 +46,7 @@ except ImportError:
 
 from indicators import rsi, sma, atr
 import config  # noqa: F401 — auto-loads /home/linuxuser/.trading_env
-from notify import notify
+from notify import notify, now_et
 
 
 # Known instruments (already tested)
@@ -483,7 +483,7 @@ def main():
         save_note = ""
 
     msg = (
-        f"🔎 <b>UNIVERSE DISCOVERY — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"🔎 <b>UNIVERSE DISCOVERY — {now_et().strftime('%H:%M ET')}</b>\n"
         f"\n"
         f"Candidates scanned: {len(liquid_candidates)}\n"
         f"New passes: {len(new_passes)} | New fails: {len(new_fails)}\n"

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -35,6 +35,14 @@ import os
 import json
 import requests
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
+_ET = ZoneInfo("America/New_York")
+
+
+def now_et() -> datetime:
+    """Current time in America/New_York (ET), for display in notifications."""
+    return datetime.now(_ET)
 
 
 BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
@@ -239,7 +247,7 @@ def critical_alert(message: str):
         f"\n"
         f"{message}\n"
         f"\n"
-        f"<i>{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</i>"
+        f"<i>{now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
     )
     # Send with notification sound (silent=False)
     notify(msg, silent=False)
@@ -252,7 +260,7 @@ def drawdown_alert(drawdown_pct: float, action: str):
         f"\n"
         f"Action taken: {action}\n"
         f"\n"
-        f"<i>{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</i>"
+        f"<i>{now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
     )
     notify(msg, silent=False)
 

--- a/skills/screener/screener.py
+++ b/skills/screener/screener.py
@@ -25,7 +25,7 @@ from alpaca.data.timeframe import TimeFrame
 import config
 from config import Keys, get_redis, get_active_instruments, get_tier, is_crypto
 from indicators import rsi, sma, atr, adx
-from notify import notify
+from notify import notify, now_et
 
 
 def fetch_daily_bars(symbol, stock_client, crypto_client, days=365):
@@ -232,7 +232,7 @@ def run_scan():
         watchlist_block = "No instruments near entry conditions"
 
     msg = (
-        f"📡 <b>SCREENER — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"📡 <b>SCREENER — {now_et().strftime('%H:%M ET')}</b>\n"
         f"\n"
         f"Regime: {regime_emoji} <b>{regime}</b> (ADX={adx_val})\n"
         f"Scanned: {len(instruments)} instruments\n"

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -29,7 +29,7 @@ from config import (
 )
 from notify import (
     notify, daily_summary, weekly_summary, critical_alert,
-    drawdown_alert, universe_update,
+    drawdown_alert, universe_update, now_et,
 )
 
 
@@ -217,7 +217,7 @@ def run_health_check(r):
         issue_block = "\n\n⚠️ <b>Issues:</b>\n" + "\n".join(f"  • {i}" for i in issues)
 
     msg = (
-        f"🔍 <b>HEALTH — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"🔍 <b>HEALTH — {now_et().strftime('%H:%M ET')}</b>\n"
         f"\n"
         f"System: {status} | Equity: ${equity:,.2f} | DD: {dd:.1f}%\n"
         f"Positions: {len(positions)} | PDT: {pdt}/3\n"
@@ -400,7 +400,7 @@ def reset_daily(r):
     agent_line = "All agents alive" if not stale_agents else f"Stale: {', '.join(stale_agents)}"
 
     msg = (
-        f"🌅 <b>MARKET OPEN — {datetime.now().strftime('%A, %b %-d')}</b>\n"
+        f"🌅 <b>MARKET OPEN — {now_et().strftime('%A, %b %-d')}</b>\n"
         f"\n"
         f"Equity: <b>${equity:,.2f}</b> | Drawdown: {dd:.1f}%\n"
         f"Open positions: {len(positions)} | PDT: {pdt}/3\n"


### PR DESCRIPTION
All Telegram notification headers and timestamps were using datetime.now() (UTC on the VPS) with 12h AM/PM format.

Add now_et() helper to notify.py using zoneinfo.ZoneInfo("America/New_York") and update all display-only strftime calls:

  - notify.py:         critical_alert, drawdown_alert timestamps
  - supervisor.py:     HEALTH and MARKET OPEN message headers
  - screener.py:       SCREENER message header
  - discover_universe.py: UNIVERSE DISCOVERY message header

Arithmetic datetime.now() calls (age calculations, hold days, etc.) are left unchanged — they compare local timestamps against other local timestamps and the relative math stays correct.