### PR TITLE
Fix notification timestamps to use Eastern Time in 24h format

### DIFF
--- a/scripts/discover_universe.py
+++ b/scripts/discover_universe.py
@@ -46,7 +46,7 @@ except ImportError:
 
 from indicators import rsi, sma, atr
 import config  # noqa: F401 — auto-loads /home/linuxuser/.trading_env
-from notify import notify
+from notify import notify, now_et
 
 
 # Known instruments (already tested)
@@ -483,7 +483,7 @@ def main():
         save_note = ""
 
     msg = (
-        f"🔎 <b>UNIVERSE DISCOVERY — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"🔎 <b>UNIVERSE DISCOVERY — {now_et().strftime('%H:%M ET')}</b>\n"
         f"\n"
         f"Candidates scanned: {len(liquid_candidates)}\n"
         f"New passes: {len(new_passes)} | New fails: {len(new_fails)}\n"

--- a/scripts/discover_universe.py
+++ b/scripts/discover_universe.py
@@ -46,7 +46,7 @@ except ImportError:
 
 from indicators import rsi, sma, atr
 import config  # noqa: F401 — auto-loads /home/linuxuser/.trading_env
-from notify import notify, now_et
+from notify import notify, fmt_et
 
 
 # Known instruments (already tested)
@@ -483,7 +483,7 @@ def main():
         save_note = ""
 
     msg = (
-        f"🔎 <b>UNIVERSE DISCOVERY — {now_et().strftime('%H:%M ET')}</b>\n"
+        f"🔎 <b>UNIVERSE DISCOVERY — {fmt_et()}</b>\n"
         f"\n"
         f"Candidates scanned: {len(liquid_candidates)}\n"
         f"New passes: {len(new_passes)} | New fails: {len(new_fails)}\n"

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -38,11 +38,29 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 _ET = ZoneInfo("America/New_York")
+_UTC = ZoneInfo("UTC")
 
 
-def now_et() -> datetime:
-    """Current time in America/New_York (ET), for display in notifications."""
+def _now_et() -> datetime:
+    """Current time in America/New_York. Internal use only."""
     return datetime.now(_ET)
+
+
+def fmt_et(dt: datetime = None, fmt: str = "%H:%M ET") -> str:
+    """Format a datetime in Eastern Time for display in notifications.
+
+    Scripts should call this instead of doing their own TZ math.
+    - If dt is None, uses the current time.
+    - Naive datetimes are assumed to be UTC (the VPS runs in UTC).
+    - fmt defaults to 24-hour HH:MM with an 'ET' suffix.
+    """
+    if dt is None:
+        return __now_et().strftime(fmt)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_UTC).astimezone(_ET)
+    else:
+        dt = dt.astimezone(_ET)
+    return dt.strftime(fmt)
 
 
 BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
@@ -247,7 +265,7 @@ def critical_alert(message: str):
         f"\n"
         f"{message}\n"
         f"\n"
-        f"<i>{now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
+        f"<i>{_now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
     )
     # Send with notification sound (silent=False)
     notify(msg, silent=False)
@@ -260,7 +278,7 @@ def drawdown_alert(drawdown_pct: float, action: str):
         f"\n"
         f"Action taken: {action}\n"
         f"\n"
-        f"<i>{now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
+        f"<i>{_now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
     )
     notify(msg, silent=False)
 

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -35,6 +35,14 @@ import os
 import json
 import requests
 from datetime import datetime
+from zoneinfo import ZoneInfo
+
+_ET = ZoneInfo("America/New_York")
+
+
+def now_et() -> datetime:
+    """Current time in America/New_York (ET), for display in notifications."""
+    return datetime.now(_ET)
 
 
 BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
@@ -239,7 +247,7 @@ def critical_alert(message: str):
         f"\n"
         f"{message}\n"
         f"\n"
-        f"<i>{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</i>"
+        f"<i>{now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
     )
     # Send with notification sound (silent=False)
     notify(msg, silent=False)
@@ -252,7 +260,7 @@ def drawdown_alert(drawdown_pct: float, action: str):
         f"\n"
         f"Action taken: {action}\n"
         f"\n"
-        f"<i>{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}</i>"
+        f"<i>{now_et().strftime('%Y-%m-%d %H:%M:%S ET')}</i>"
     )
     notify(msg, silent=False)
 

--- a/skills/screener/screener.py
+++ b/skills/screener/screener.py
@@ -25,7 +25,7 @@ from alpaca.data.timeframe import TimeFrame
 import config
 from config import Keys, get_redis, get_active_instruments, get_tier, is_crypto
 from indicators import rsi, sma, atr, adx
-from notify import notify
+from notify import notify, now_et
 
 
 def fetch_daily_bars(symbol, stock_client, crypto_client, days=365):
@@ -232,7 +232,7 @@ def run_scan():
         watchlist_block = "No instruments near entry conditions"
 
     msg = (
-        f"📡 <b>SCREENER — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"📡 <b>SCREENER — {now_et().strftime('%H:%M ET')}</b>\n"
         f"\n"
         f"Regime: {regime_emoji} <b>{regime}</b> (ADX={adx_val})\n"
         f"Scanned: {len(instruments)} instruments\n"

--- a/skills/screener/screener.py
+++ b/skills/screener/screener.py
@@ -25,7 +25,7 @@ from alpaca.data.timeframe import TimeFrame
 import config
 from config import Keys, get_redis, get_active_instruments, get_tier, is_crypto
 from indicators import rsi, sma, atr, adx
-from notify import notify, now_et
+from notify import notify, fmt_et
 
 
 def fetch_daily_bars(symbol, stock_client, crypto_client, days=365):
@@ -232,7 +232,7 @@ def run_scan():
         watchlist_block = "No instruments near entry conditions"
 
     msg = (
-        f"📡 <b>SCREENER — {now_et().strftime('%H:%M ET')}</b>\n"
+        f"📡 <b>SCREENER — {fmt_et()}</b>\n"
         f"\n"
         f"Regime: {regime_emoji} <b>{regime}</b> (ADX={adx_val})\n"
         f"Scanned: {len(instruments)} instruments\n"

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -29,7 +29,7 @@ from config import (
 )
 from notify import (
     notify, daily_summary, weekly_summary, critical_alert,
-    drawdown_alert, universe_update,
+    drawdown_alert, universe_update, now_et,
 )
 
 
@@ -217,7 +217,7 @@ def run_health_check(r):
         issue_block = "\n\n⚠️ <b>Issues:</b>\n" + "\n".join(f"  • {i}" for i in issues)
 
     msg = (
-        f"🔍 <b>HEALTH — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"🔍 <b>HEALTH — {now_et().strftime('%H:%M ET')}</b>\n"
         f"\n"
         f"System: {status} | Equity: ${equity:,.2f} | DD: {dd:.1f}%\n"
         f"Positions: {len(positions)} | PDT: {pdt}/3\n"
@@ -400,7 +400,7 @@ def reset_daily(r):
     agent_line = "All agents alive" if not stale_agents else f"Stale: {', '.join(stale_agents)}"
 
     msg = (
-        f"🌅 <b>MARKET OPEN — {datetime.now().strftime('%A, %b %-d')}</b>\n"
+        f"🌅 <b>MARKET OPEN — {now_et().strftime('%A, %b %-d')}</b>\n"
         f"\n"
         f"Equity: <b>${equity:,.2f}</b> | Drawdown: {dd:.1f}%\n"
         f"Open positions: {len(positions)} | PDT: {pdt}/3\n"

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -29,7 +29,7 @@ from config import (
 )
 from notify import (
     notify, daily_summary, weekly_summary, critical_alert,
-    drawdown_alert, universe_update, now_et,
+    drawdown_alert, universe_update, fmt_et,
 )
 
 
@@ -217,7 +217,7 @@ def run_health_check(r):
         issue_block = "\n\n⚠️ <b>Issues:</b>\n" + "\n".join(f"  • {i}" for i in issues)
 
     msg = (
-        f"🔍 <b>HEALTH — {now_et().strftime('%H:%M ET')}</b>\n"
+        f"🔍 <b>HEALTH — {fmt_et()}</b>\n"
         f"\n"
         f"System: {status} | Equity: ${equity:,.2f} | DD: {dd:.1f}%\n"
         f"Positions: {len(positions)} | PDT: {pdt}/3\n"
@@ -400,7 +400,7 @@ def reset_daily(r):
     agent_line = "All agents alive" if not stale_agents else f"Stale: {', '.join(stale_agents)}"
 
     msg = (
-        f"🌅 <b>MARKET OPEN — {now_et().strftime('%A, %b %-d')}</b>\n"
+        f"🌅 <b>MARKET OPEN — {fmt_et(fmt='%A, %b %-d')}</b>\n"
         f"\n"
         f"Equity: <b>${equity:,.2f}</b> | Drawdown: {dd:.1f}%\n"
         f"Open positions: {len(positions)} | PDT: {pdt}/3\n"

--- a/skills/watcher/watcher.py
+++ b/skills/watcher/watcher.py
@@ -25,7 +25,7 @@ from alpaca.data.timeframe import TimeFrame
 import config
 from config import Keys, get_redis, get_simulated_equity, is_crypto
 from indicators import rsi, sma, atr
-from notify import notify
+from notify import notify, fmt_et
 
 
 def fetch_recent_bars(symbol, stock_client, crypto_client, days=10):
@@ -318,7 +318,7 @@ def run_cycle():
     signal_block = "\n".join(signal_lines) if signal_lines else "No signals this cycle"
 
     msg = (
-        f"👁 <b>WATCHER — {datetime.now().strftime('%-I:%M %p')}</b>\n"
+        f"👁 <b>WATCHER — {fmt_et()}</b>\n"
         f"\n"
         f"Watchlist: {len(watchlist)} items | Positions: {len(positions)}\n"
         f"System: {status}\n"


### PR DESCRIPTION
## Summary

- Added centralized `fmt_et()` helper function in `notify.py` for consistent Eastern Time formatting
- Updated all notification timestamps across the system to display in 24-hour ET format instead of ambiguous local time
- Ensures trading notifications show timestamps in the relevant market timezone (America/New_York)

## Changes

- `scripts/notify.py`: Added `fmt_et()` function; updated `critical_alert()` and `drawdown_alert()`
- `scripts/discover_universe.py`: Universe discovery notifications now use ET
- `skills/screener/screener.py`: Screener notifications now use ET  
- `skills/supervisor/supervisor.py`: Health check and market open notifications now use ET
- `skills/watcher/watcher.py`: Watcher cycle notifications now use ET

## Test plan

- [ ] Verify notifications display timestamps in format `HH:MM ET` (e.g., "14:30 ET")
- [ ] Confirm critical alerts and drawdown alerts show full datetime with ET suffix
- [ ] Check that all notification types (screener, watcher, supervisor, discovery) use consistent ET formatting
- [ ] Validate that naive datetimes are correctly interpreted as UTC and converted to ET

🤖 Generated with [Claude Code](https://claude.com/claude-code)