### PR TITLE
fix: market hours awareness, notification dedup, and exit signal dedup

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -135,6 +135,12 @@ class Keys:
     def whipsaw(symbol: str) -> str:
         return f"trading:whipsaw:{symbol}"
 
+    @staticmethod
+    def exit_signaled(symbol: str) -> str:
+        """Set when an exit signal is dispatched; cleared on confirmed sell.
+        Prevents the same daily-bar condition from re-firing every cycle."""
+        return f"trading:exit_signaled:{symbol}"
+
 
 # ── Redis Connection ────────────────────────────────────────
 

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -341,6 +341,10 @@ def execute_sell(r, trading_client, order):
         del positions[symbol]
         r.set(Keys.POSITIONS, json.dumps(positions))
 
+        # Clear the watcher's exit-signaled flag so a future re-entry on this
+        # symbol can exit normally rather than being silently suppressed.
+        r.delete(Keys.exit_signaled(symbol))
+
         # Calculate hold days
         try:
             entry_dt = datetime.strptime(pos["entry_date"], "%Y-%m-%d")

--- a/skills/watcher/watcher.py
+++ b/skills/watcher/watcher.py
@@ -274,6 +274,19 @@ def generate_exit_signals(r, stock_client, crypto_client):
             }
 
         if exit_signal:
+            # Deduplicate: skip if we already dispatched an exit signal for this
+            # symbol and it hasn't been cleared by a confirmed sell yet.  This
+            # prevents daily-bar conditions (RSI > 60, close > prev high, time
+            # stop) from re-firing on every 30-minute cycle until the market
+            # reopens and the executor can actually execute the sell.
+            if r.exists(Keys.exit_signaled(symbol)):
+                print(f"  [Watcher] {symbol}: exit already signaled — awaiting execution")
+                continue
+
+            # Mark as dispatched; 48-hour TTL self-clears if the executor never
+            # acts (e.g. server-side stop-loss fires and bypasses executor).
+            r.set(Keys.exit_signaled(symbol), exit_signal["signal_type"], ex=172800)
+
             pnl_pct = (exit_signal["exit_price"] - entry_price) / entry_price * 100
             signal = {
                 "time": datetime.now().isoformat(),


### PR DESCRIPTION
## Summary

- **Market hours awareness** — watcher skips equity entry/exit signals when the market is closed (crypto is unaffected); executor gates equity buys behind the same Alpaca clock check already used for equity sells
- **Holiday support** — `is_market_hours()` in the watcher now calls `trading_client.get_clock().is_open` (Alpaca's authoritative clock, holiday- and early-close-aware) instead of a hand-rolled weekday + time check; falls back to the old logic if the API call fails
- **Notification dedup** — watcher only sends Telegram notifications when signals are actually detected; removes the every-cycle heartbeat that was firing every 5 min during hours and every 30 min overnight
- **Exit signal dedup** — exit signals set `trading:exit_signaled:{symbol}` in Redis so the same daily-bar condition (RSI > 60, close > prev high, time stop) can't re-fire on every 30-minute cycle while waiting for the market to open; executor clears the flag on confirmed sell; 48h TTL handles server-side stop-loss triggers that bypass the executor

## Test plan

- [ ] Confirm no Telegram notifications arrive during off-hours when no positions are held
- [ ] Confirm a crypto exit condition triggers exactly one notification, not one per cycle
- [ ] Confirm equity entry/exit signals are generated normally during market hours
- [ ] Confirm a holiday (or manually closed Alpaca paper clock) causes equity signals to be skipped
- [ ] Confirm re-entering a symbol after a sell generates exit signals normally on the new position

🤖 Generated with [Claude Code](https://claude.com/claude-code)