### PR TITLE
feat: add pytest-cov + Coveralls CI coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests with coverage
+        run: pytest --cov=skills --cov=scripts --cov-report=lcov --cov-report=term-missing
+        env:
+          PYTHONPATH: scripts
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ dashboard/_build/
 mix.lock
 dashboard/mix.lock
 
+.coverage
+
 # v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.pytest.ini_options]
+testpaths = ["skills"]
+pythonpath = ["scripts"]
+
+[tool.coverage.run]
+source = ["skills", "scripts"]
+omit = ["**/test_*.py", "**/__pycache__/**"]
+
+[tool.coverage.report]
+show_missing = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-cov
+coveralls


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow (`.github/workflows/tests.yml`) that runs the test suite on every push/PR and uploads coverage to Coveralls
- Public repo — uses `GITHUB_TOKEN` only, no `COVERALLS_REPO_TOKEN` needed
- `requirements-dev.txt` for test dependencies (`pytest`, `pytest-cov`, `coveralls`)
- `pyproject.toml` for pytest config (`testpaths = skills`, `pythonpath = scripts`) and coverage source/omit rules

## Test plan

- [ ] Merge and confirm GitHub Actions workflow runs green
- [ ] Enable repo at [coveralls.io](https://coveralls.io) → Add Repos → `texastoasters/trading-system`
- [ ] Confirm coverage badge appears on Coveralls dashboard after first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)