### PR TITLE
test(indicators): 100% coverage for indicators.py (30 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/texastoasters/trading-system/badge.svg?branch=main)](https://coveralls.io/github/texastoasters/trading-system?branch=main)
+
 # Autonomous Agentic Day Trading System
 
 An autonomous trading system powered by five LLM-orchestrated agents, trading RSI-2 mean reversion across a dynamic universe of 17+ instruments via Alpaca's API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.pytest.ini_options]
+testpaths = ["skills", "scripts"]
+pythonpath = ["scripts"]
+
+[tool.coverage.run]
+source = ["skills", "scripts"]
+omit = ["**/test_*.py", "**/__pycache__/**"]
+
+[tool.coverage.report]
+show_missing = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 coveralls
+numpy

--- a/scripts/indicators.py
+++ b/scripts/indicators.py
@@ -248,7 +248,7 @@ def compute_all_daily(high, low, close, volume):
     }
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     # Quick self-test with synthetic data
     np.random.seed(42)
     n = 300

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -299,7 +299,7 @@ def universe_update(changes: list, total_instruments: int):
 
 # ── Self-test ───────────────────────────────────────────────
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     if not BOT_TOKEN or not CHAT_ID:
         print("Set TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID to test")
         print("Falling back to console output:\n")

--- a/scripts/test_config.py
+++ b/scripts/test_config.py
@@ -1,0 +1,232 @@
+"""
+Tests for config.py — 100% coverage target.
+
+Run from repo root:
+    PYTHONPATH=scripts pytest scripts/test_config.py -v
+"""
+import json
+import sys
+import os
+from unittest.mock import MagicMock, patch, mock_open
+
+import pytest
+
+sys.path.insert(0, "scripts")
+
+# redis must be mocked before config is imported
+if "redis" not in sys.modules:
+    sys.modules["redis"] = MagicMock()
+
+import config
+from config import (
+    Keys, _load_trading_env,
+    get_redis, init_redis_state,
+    get_active_instruments, get_tier,
+    get_simulated_equity, get_drawdown,
+    is_crypto, get_sector,
+    DEFAULT_UNIVERSE, DEFAULT_TIERS, INITIAL_CAPITAL,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+def make_r(exists=False, store=None):
+    """Minimal mock Redis where r.get reads from store and r.exists is configurable."""
+    store = store or {}
+    r = MagicMock()
+    r.exists = MagicMock(return_value=1 if exists else 0)
+    r.get = lambda k: store.get(k)
+    r.set = MagicMock()
+    return r
+
+
+# ── _load_trading_env ────────────────────────────────────────
+
+class TestLoadTradingEnv:
+    def test_missing_file_returns_early(self):
+        # Path doesn't exist → returns without touching os.environ
+        with patch("config.os.path.exists", return_value=False):
+            before = dict(os.environ)
+            _load_trading_env()
+            assert dict(os.environ) == before
+
+    def test_parses_all_line_formats(self):
+        """
+        Exercises every branch in the parsing loop:
+        - blank line → skip
+        - comment (#) → skip
+        - export KEY="val" → strip prefix + double quotes
+        - export KEY='val' → strip prefix + single quotes
+        - KEY=val → no prefix, no quotes
+        - NO_EQUALS → skip (no = in line)
+        """
+        fake_env = (
+            "\n"                            # blank → skip
+            "# comment line\n"             # comment → skip
+            "export TCFG_DOUBLE=\"dval\"\n" # export + double quotes
+            "export TCFG_SINGLE='sval'\n"  # export + single quotes
+            "TCFG_BARE=bval\n"             # no export prefix
+            "TCFG_NO_EQUALS\n"             # no = → skip
+        )
+        with patch("config.os.path.exists", return_value=True), \
+             patch("builtins.open", mock_open(read_data=fake_env)):
+            _load_trading_env()
+
+        assert os.environ.get("TCFG_DOUBLE") == "dval"
+        assert os.environ.get("TCFG_SINGLE") == "sval"
+        assert os.environ.get("TCFG_BARE") == "bval"
+        assert "TCFG_NO_EQUALS" not in os.environ
+
+
+# ── Keys ─────────────────────────────────────────────────────
+
+class TestKeys:
+    def test_heartbeat(self):
+        assert Keys.heartbeat("screener") == "trading:heartbeat:screener"
+
+    def test_whipsaw(self):
+        assert Keys.whipsaw("SPY") == "trading:whipsaw:SPY"
+
+    def test_exit_signaled(self):
+        assert Keys.exit_signaled("QQQ") == "trading:exit_signaled:QQQ"
+
+    def test_manual_exit(self):
+        assert Keys.manual_exit("NVDA") == "trading:manual_exit:NVDA"
+
+
+# ── get_redis ─────────────────────────────────────────────────
+
+class TestGetRedis:
+    def test_calls_redis_constructor(self):
+        mock_redis_cls = MagicMock()
+        with patch("config.redis.Redis", mock_redis_cls):
+            get_redis()
+        mock_redis_cls.assert_called_once_with(
+            host="localhost", port=6379, decode_responses=True
+        )
+
+
+# ── init_redis_state ──────────────────────────────────────────
+
+class TestInitRedisState:
+    def test_sets_all_defaults_when_keys_missing(self):
+        r = make_r(exists=False)
+        init_redis_state(r)
+        # All 10 keys should have been set
+        assert r.set.call_count == 10
+
+    def test_skips_existing_keys(self):
+        r = make_r(exists=True)
+        init_redis_state(r)
+        r.set.assert_not_called()
+
+
+# ── get_active_instruments ────────────────────────────────────
+
+class TestGetActiveInstruments:
+    def test_returns_all_tiers_from_redis(self):
+        universe = {
+            "tier1": ["SPY"], "tier2": ["QQQ"], "tier3": ["IWM"],
+            "disabled": ["DEAD"], "archived": [],
+        }
+        r = make_r(store={Keys.UNIVERSE: json.dumps(universe)})
+        result = get_active_instruments(r)
+        assert result == ["SPY", "QQQ", "IWM"]
+        assert "DEAD" not in result
+
+    def test_falls_back_to_default_when_key_missing(self):
+        r = make_r(store={})
+        result = get_active_instruments(r)
+        assert "SPY" in result
+        assert "QQQ" in result
+
+
+# ── get_tier ──────────────────────────────────────────────────
+
+class TestGetTier:
+    def test_known_symbol_returns_tier(self):
+        r = make_r(store={Keys.TIERS: json.dumps({"SPY": 1, "QQQ": 1})})
+        assert get_tier(r, "SPY") == 1
+
+    def test_unknown_symbol_returns_99(self):
+        r = make_r(store={Keys.TIERS: json.dumps({"SPY": 1})})
+        assert get_tier(r, "UNKNOWN") == 99
+
+    def test_falls_back_to_default_tiers_when_key_missing(self):
+        r = make_r(store={})
+        assert get_tier(r, "SPY") == 1
+
+
+# ── get_simulated_equity ──────────────────────────────────────
+
+class TestGetSimulatedEquity:
+    def test_returns_float_from_redis(self):
+        r = make_r(store={Keys.SIMULATED_EQUITY: "4750.50"})
+        assert get_simulated_equity(r) == pytest.approx(4750.50)
+
+    def test_falls_back_to_initial_capital_when_missing(self):
+        r = make_r(store={})
+        assert get_simulated_equity(r) == pytest.approx(INITIAL_CAPITAL)
+
+
+# ── get_drawdown ──────────────────────────────────────────────
+
+class TestGetDrawdown:
+    def test_positive_drawdown(self):
+        # equity=4000, peak=5000 → drawdown=20%
+        r = make_r(store={
+            Keys.SIMULATED_EQUITY: "4000.0",
+            Keys.PEAK_EQUITY: "5000.0",
+        })
+        assert get_drawdown(r) == pytest.approx(20.0)
+
+    def test_no_drawdown_when_at_peak(self):
+        r = make_r(store={
+            Keys.SIMULATED_EQUITY: "5000.0",
+            Keys.PEAK_EQUITY: "5000.0",
+        })
+        assert get_drawdown(r) == pytest.approx(0.0)
+
+    def test_peak_zero_returns_zero(self):
+        r = make_r(store={
+            Keys.SIMULATED_EQUITY: "5000.0",
+            Keys.PEAK_EQUITY: "0.0",
+        })
+        assert get_drawdown(r) == 0.0
+
+
+# ── is_crypto ─────────────────────────────────────────────────
+
+class TestIsCrypto:
+    def test_btc_is_crypto(self):
+        assert is_crypto("BTC/USD") is True
+
+    def test_spy_is_not_crypto(self):
+        assert is_crypto("SPY") is False
+
+
+# ── get_sector ────────────────────────────────────────────────
+
+class TestGetSector:
+    def test_known_symbol(self):
+        assert get_sector("SPY") == "broad"
+        assert get_sector("BTC/USD") == "crypto"
+
+    def test_unknown_symbol_returns_unknown(self):
+        assert get_sector("UNKNOWN_TICKER") == "unknown"
+
+
+# ── DEFAULT_TIERS (module-level loop) ────────────────────────
+
+class TestDefaultTiers:
+    def test_tier1_symbols_mapped(self):
+        for sym in DEFAULT_UNIVERSE["tier1"]:
+            assert DEFAULT_TIERS[sym] == 1
+
+    def test_tier2_symbols_mapped(self):
+        for sym in DEFAULT_UNIVERSE["tier2"]:
+            assert DEFAULT_TIERS[sym] == 2
+
+    def test_tier3_symbols_mapped(self):
+        for sym in DEFAULT_UNIVERSE["tier3"]:
+            assert DEFAULT_TIERS[sym] == 3

--- a/scripts/test_indicators.py
+++ b/scripts/test_indicators.py
@@ -1,0 +1,281 @@
+"""
+Tests for indicators.py — 100% statement coverage target.
+
+Run from repo root:
+    PYTHONPATH=scripts pytest scripts/test_indicators.py -v
+"""
+import sys
+import numpy as np
+import pytest
+
+sys.path.insert(0, "scripts")
+from indicators import (
+    sma, ema, rsi, atr, adx, macd, vwap, relative_volume, compute_all_daily,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+def make_trending(n=100, seed=42, start=100.0, step=0.5):
+    """Monotonically rising price series."""
+    np.random.seed(seed)
+    close = start + np.cumsum(np.abs(np.random.randn(n)) * step)
+    high = close + np.abs(np.random.randn(n) * 0.3)
+    low = close - np.abs(np.random.randn(n) * 0.3)
+    volume = np.random.randint(100_000, 1_000_000, n).astype(float)
+    return high, low, close, volume
+
+
+# ── SMA ──────────────────────────────────────────────────────
+
+class TestSma:
+    def test_insufficient_data_returns_all_nan(self):
+        result = sma(np.array([1.0, 2.0]), period=3)
+        assert np.all(np.isnan(result))
+
+    def test_correct_rolling_values(self):
+        close = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = sma(close, period=3)
+        assert np.isnan(result[0]) and np.isnan(result[1])
+        assert result[2] == pytest.approx(2.0)
+        assert result[3] == pytest.approx(3.0)
+        assert result[4] == pytest.approx(4.0)
+
+    def test_period_equals_length(self):
+        close = np.array([2.0, 4.0, 6.0])
+        result = sma(close, period=3)
+        assert result[2] == pytest.approx(4.0)
+
+
+# ── EMA ──────────────────────────────────────────────────────
+
+class TestEma:
+    def test_insufficient_data_returns_all_nan(self):
+        result = ema(np.array([1.0, 2.0]), period=3)
+        assert np.all(np.isnan(result))
+
+    def test_seeds_with_sma(self):
+        close = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = ema(close, period=3)
+        assert np.isnan(result[0]) and np.isnan(result[1])
+        assert result[2] == pytest.approx(2.0)  # mean([1,2,3])
+
+    def test_smoothing_after_seed(self):
+        # period=3, alpha=0.5; seed=mean([1,2,3])=2; next: 0.5*4 + 0.5*2 = 3
+        close = np.array([1.0, 2.0, 3.0, 4.0])
+        result = ema(close, period=3)
+        alpha = 2.0 / (3 + 1)
+        assert result[3] == pytest.approx(alpha * 4.0 + (1 - alpha) * 2.0)
+
+    def test_longer_series_all_valid_after_seed(self):
+        _, _, close, _ = make_trending(n=50)
+        result = ema(close, period=10)
+        assert np.all(np.isnan(result[:9]))
+        assert np.all(~np.isnan(result[9:]))
+
+
+# ── RSI ──────────────────────────────────────────────────────
+
+class TestRsi:
+    def test_insufficient_data_returns_all_nan(self):
+        # need len >= period + 1
+        result = rsi(np.array([1.0, 2.0]), period=2)
+        assert np.all(np.isnan(result))
+
+    def test_all_gains_seed_avg_loss_zero(self):
+        # avg_loss == 0 at seed → RSI = 100 (line 53-54)
+        # then avg_loss stays 0 in Wilder loop → line 63-64
+        close = np.array([100.0, 101.0, 102.0, 103.0])
+        result = rsi(close, period=2)
+        assert result[2] == pytest.approx(100.0)  # seed path
+        assert result[3] == pytest.approx(100.0)  # Wilder loop path
+
+    def test_mixed_moves_avg_loss_nonzero(self):
+        # avg_loss != 0 at seed → lines 56-57; non-zero loss in loop → lines 65-67
+        close = np.array([100.0, 99.0, 101.0, 100.0, 102.0])
+        result = rsi(close, period=2)
+        valid = result[~np.isnan(result)]
+        assert len(valid) > 0
+        assert np.all(valid >= 0.0) and np.all(valid <= 100.0)
+        # Not all 100 — some losses present
+        assert not np.all(valid == 100.0)
+
+    def test_values_bounded_on_random_data(self):
+        _, _, close, _ = make_trending(n=100)
+        result = rsi(close, period=14)
+        valid = result[~np.isnan(result)]
+        assert np.all(valid >= 0.0) and np.all(valid <= 100.0)
+
+
+# ── ATR ──────────────────────────────────────────────────────
+
+class TestAtr:
+    def test_insufficient_data_returns_all_nan(self):
+        arr = np.array([1.0, 2.0])
+        result = atr(arr, arr, arr, period=3)
+        assert np.all(np.isnan(result))
+
+    def test_constant_bars(self):
+        # H-L = 2 always; no prev-close contribution (prev=curr)
+        n = 20
+        close = np.ones(n) * 100.0
+        high = close + 1.0
+        low = close - 1.0
+        result = atr(high, low, close, period=5)
+        valid = result[~np.isnan(result)]
+        assert np.allclose(valid, 2.0, atol=0.01)
+
+    def test_tr_uses_high_minus_prev_close(self):
+        # Gap up: |H - prev_C| dominates
+        high  = np.array([100.0, 120.0, 121.0, 122.0, 123.0, 124.0])
+        low   = np.array([ 99.0, 118.0, 119.0, 120.0, 121.0, 122.0])
+        close = np.array([100.0, 119.0, 120.0, 121.0, 122.0, 123.0])
+        result = atr(high, low, close, period=2)
+        assert not np.all(np.isnan(result))
+
+    def test_tr_uses_low_minus_prev_close(self):
+        # Gap down: |L - prev_C| dominates
+        high  = np.array([100.0,  81.0,  82.0,  83.0,  84.0,  85.0])
+        low   = np.array([ 99.0,  79.0,  80.0,  81.0,  82.0,  83.0])
+        close = np.array([100.0,  80.0,  81.0,  82.0,  83.0,  84.0])
+        result = atr(high, low, close, period=2)
+        assert not np.all(np.isnan(result))
+
+    def test_wilder_smoothing(self):
+        _, _, close, _ = make_trending(n=50)
+        high = close + 1.0
+        low = close - 1.0
+        result = atr(high, low, close, period=14)
+        valid = result[~np.isnan(result)]
+        assert len(valid) > 0
+        assert np.all(valid > 0)
+
+
+# ── ADX ──────────────────────────────────────────────────────
+
+class TestAdx:
+    def test_insufficient_data_returns_all_nan(self):
+        period = 14
+        n = period * 2  # one short of required period*2+1
+        arr = np.ones(n)
+        adx_vals, pdi, mdi = adx(arr, arr, arr, period)
+        assert np.all(np.isnan(adx_vals))
+        assert np.all(np.isnan(pdi))
+        assert np.all(np.isnan(mdi))
+
+    def test_flat_bars_atr_zero_and_di_sum_zero(self):
+        # All bars identical: TR=0, +DM=0, -DM=0
+        # → atr_smooth=0 → pdi=mdi=0 (line 150-152)
+        # → di_sum=0 → dx=0 (line 158-159)
+        period = 3
+        n = period * 2 + 5
+        arr = np.ones(n) * 100.0
+        adx_vals, pdi, mdi = adx(arr, arr, arr, period)
+        valid_pdi = pdi[~np.isnan(pdi)]
+        valid_mdi = mdi[~np.isnan(mdi)]
+        assert np.all(valid_pdi == 0.0)
+        assert np.all(valid_mdi == 0.0)
+
+    def test_trending_data_produces_valid_adx(self):
+        high, low, close, _ = make_trending(n=100)
+        adx_vals, pdi, mdi = adx(high, low, close, period=14)
+        valid = adx_vals[~np.isnan(adx_vals)]
+        assert len(valid) > 0
+        assert np.all(valid >= 0.0)
+
+    def test_first_and_subsequent_iterations_both_hit(self):
+        # period=3, n=10: loop runs from i=3 to 9, hitting i==period (True) once
+        # and i>period (False) multiple times — covers lines 141-148
+        period = 3
+        high, low, close, _ = make_trending(n=20)
+        adx_vals, pdi, mdi = adx(high, low, close, period)
+        valid = adx_vals[~np.isnan(adx_vals)]
+        assert len(valid) > 0
+
+
+# ── MACD ─────────────────────────────────────────────────────
+
+class TestMacd:
+    def test_insufficient_data_first_valid_is_none(self):
+        # len < slow → ema_slow all NaN → macd_line all NaN → first_valid = None
+        close = np.ones(5)
+        ml, sl, hist = macd(close, fast=3, slow=10, signal=3)
+        assert np.all(np.isnan(ml))
+        assert np.all(np.isnan(sl))
+
+    def test_valid_macd_but_not_enough_for_signal(self):
+        # len=30: first_valid=25, len-first_valid=5 < signal=9 → signal all NaN
+        close = np.ones(30) * 100.0
+        ml, sl, hist = macd(close, fast=12, slow=26, signal=9)
+        assert not np.all(np.isnan(ml))   # MACD line has values
+        assert np.all(np.isnan(sl))        # signal line does not
+
+    def test_normal_full_case(self):
+        _, _, close, _ = make_trending(n=100)
+        ml, sl, hist = macd(close)
+        valid_ml = ml[~np.isnan(ml)]
+        valid_sl = sl[~np.isnan(sl)]
+        assert len(valid_ml) > 0
+        assert len(valid_sl) > 0
+
+
+# ── VWAP ─────────────────────────────────────────────────────
+
+class TestVwap:
+    def test_normal_case(self):
+        high  = np.array([11.0, 12.0, 13.0])
+        low   = np.array([ 9.0, 10.0, 11.0])
+        close = np.array([10.0, 11.0, 12.0])
+        volume = np.array([100.0, 200.0, 300.0])
+        result = vwap(high, low, close, volume)
+        tp = (high + low + close) / 3.0
+        expected = np.cumsum(tp * volume) / np.cumsum(volume)
+        np.testing.assert_allclose(result, expected)
+
+    def test_zero_volume_returns_nan(self):
+        arr = np.array([10.0, 10.0, 10.0])
+        result = vwap(arr, arr, arr, np.zeros(3))
+        assert np.all(np.isnan(result))
+
+
+# ── Relative Volume ──────────────────────────────────────────
+
+class TestRelativeVolume:
+    def test_constant_volume_gives_one(self):
+        volume = np.ones(25) * 500.0
+        result = relative_volume(volume, period=20)
+        valid = result[~np.isnan(result)]
+        assert np.allclose(valid, 1.0)
+
+    def test_zero_volume_gives_nan(self):
+        result = relative_volume(np.zeros(25), period=20)
+        # sma(zeros) = 0.0, where avg==0 → NaN
+        assert np.all(np.isnan(result[20:]))
+
+    def test_elevated_volume_ratio(self):
+        volume = np.ones(25) * 100.0
+        volume[-1] = 200.0
+        result = relative_volume(volume, period=20)
+        # sma window includes current bar: mean([100]*19 + [200]) = 105
+        expected = 200.0 / np.mean(volume[-20:])
+        assert result[-1] == pytest.approx(expected, rel=0.01)
+
+
+# ── compute_all_daily ────────────────────────────────────────
+
+class TestComputeAllDaily:
+    def test_returns_expected_keys(self):
+        high, low, close, volume = make_trending(n=300)
+        result = compute_all_daily(high, low, close, volume)
+        assert set(result.keys()) == {
+            'sma200', 'rsi2', 'rsi14', 'atr14', 'adx14',
+            'macd', 'ema9', 'ema50', 'rvol20',
+        }
+
+    def test_all_values_are_arrays(self):
+        high, low, close, volume = make_trending(n=300)
+        result = compute_all_daily(high, low, close, volume)
+        # adx14 and macd return tuples — check they're present
+        assert isinstance(result['adx14'], tuple)
+        assert isinstance(result['macd'], tuple)
+        assert isinstance(result['sma200'], np.ndarray)

--- a/scripts/test_notify.py
+++ b/scripts/test_notify.py
@@ -1,0 +1,236 @@
+"""
+Tests for notify.py — 100% coverage target.
+
+Run from repo root:
+    PYTHONPATH=scripts pytest scripts/test_notify.py -v
+"""
+import sys
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, "scripts")
+import notify
+
+
+# ── fmt_et ───────────────────────────────────────────────────
+
+class TestFmtEt:
+    def test_none_returns_current_time_string(self):
+        result = notify.fmt_et(None)
+        assert "ET" in result
+
+    def test_naive_datetime_assumed_utc(self):
+        # Naive (no tzinfo) → treated as UTC → EST is UTC-5 in January
+        dt = datetime(2026, 1, 1, 15, 0, 0)
+        assert notify.fmt_et(dt) == "10:00 ET"
+
+    def test_aware_datetime_converted_to_et(self):
+        # Already UTC-aware → same conversion
+        dt = datetime(2026, 1, 1, 15, 0, 0, tzinfo=timezone.utc)
+        assert notify.fmt_et(dt) == "10:00 ET"
+
+    def test_custom_format(self):
+        dt = datetime(2026, 6, 15, 12, 0, 0)  # EDT = UTC-4 → 08:00 ET
+        result = notify.fmt_et(dt, fmt="%H:%M")
+        assert result == "08:00"
+
+
+# ── notify ───────────────────────────────────────────────────
+
+class TestNotify:
+    def test_no_config_prints_to_console_returns_false(self, monkeypatch, capsys):
+        monkeypatch.setattr(notify, "API_URL", None)
+        monkeypatch.setattr(notify, "CHAT_ID", "")
+        result = notify.notify("hello world")
+        assert result is False
+        assert "hello world" in capsys.readouterr().out
+
+    def test_successful_api_send_returns_true(self, monkeypatch):
+        monkeypatch.setattr(notify, "API_URL", "http://fake-telegram")
+        monkeypatch.setattr(notify, "CHAT_ID", "12345")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("notify.requests.post", return_value=mock_resp):
+            result = notify.notify("sent ok")
+        assert result is True
+
+    def test_non_200_response_returns_false(self, monkeypatch):
+        monkeypatch.setattr(notify, "API_URL", "http://fake-telegram")
+        monkeypatch.setattr(notify, "CHAT_ID", "12345")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        with patch("notify.requests.post", return_value=mock_resp):
+            result = notify.notify("failed send")
+        assert result is False
+
+    def test_request_exception_prints_and_returns_false(self, monkeypatch, capsys):
+        monkeypatch.setattr(notify, "API_URL", "http://fake-telegram")
+        monkeypatch.setattr(notify, "CHAT_ID", "12345")
+        with patch("notify.requests.post", side_effect=Exception("connection timeout")):
+            result = notify.notify("message")
+        assert result is False
+        out = capsys.readouterr().out
+        assert "connection timeout" in out
+
+
+# ── trade_alert ──────────────────────────────────────────────
+
+class TestTradeAlert:
+    def test_buy_with_tier_and_reasoning(self, capsys):
+        notify.trade_alert(
+            side="buy", symbol="SPY", quantity=10, price=500.0,
+            stop_price=490.0, strategy="RSI2", tier=1, risk_pct=1.0,
+            reasoning="Strong signal",
+        )
+        out = capsys.readouterr().out
+        assert "🟢" in out
+        assert "Tier 1" in out
+        assert "Strong signal" in out
+
+    def test_sell_no_tier_no_reasoning(self, capsys):
+        notify.trade_alert(
+            side="sell", symbol="QQQ", quantity=5, price=450.0,
+            stop_price=440.0, strategy="RSI2", tier=0, risk_pct=1.0,
+        )
+        out = capsys.readouterr().out
+        assert "🔴" in out
+        assert "Tier" not in out  # tier=0 → empty label
+
+
+# ── exit_alert ───────────────────────────────────────────────
+
+class TestExitAlert:
+    def test_profitable_exit(self, capsys):
+        notify.exit_alert("SPY", 10, 500.0, 510.0, 2.0, 100.0, "rsi_exit", 3)
+        assert "✅" in capsys.readouterr().out
+
+    def test_losing_exit(self, capsys):
+        notify.exit_alert("SPY", 10, 500.0, 490.0, -2.0, -100.0, "stop_loss", 1)
+        assert "❌" in capsys.readouterr().out
+
+
+# ── daily_summary ────────────────────────────────────────────
+
+class TestDailySummary:
+    def _base(self, **overrides):
+        d = {
+            'date': '2026-04-08', 'equity': 5000.0, 'daily_pnl': 50.0,
+            'daily_pnl_pct': 1.0, 'drawdown_pct': 0.0, 'trades_today': 2,
+            'winners': 2, 'losers': 0, 'regime': 'RANGING',
+            'active_positions': 1, 'total_fees': 0.0, 'llm_cost': 0.001,
+            'peak_equity': 5000.0,
+        }
+        d.update(overrides)
+        return d
+
+    def test_positive_pnl(self, capsys):
+        notify.daily_summary(self._base(daily_pnl=50.0))
+        assert "📈" in capsys.readouterr().out
+
+    def test_negative_pnl(self, capsys):
+        notify.daily_summary(self._base(daily_pnl=-50.0))
+        assert "📉" in capsys.readouterr().out
+
+
+# ── weekly_summary ───────────────────────────────────────────
+
+class TestWeeklySummary:
+    def _base(self, **overrides):
+        d = {
+            'week': 'W15', 'equity': 5000.0, 'weekly_pnl': 100.0,
+            'weekly_pnl_pct': 2.0, 'drawdown_pct': 0.0,
+            'total_trades': 5, 'winners': 4, 'losers': 1,
+            'best_trade': 'SPY +1.2%', 'worst_trade': 'QQQ -0.4%',
+            'universe_size': 17, 'active_instruments': 17, 'disabled_instruments': 0,
+        }
+        d.update(overrides)
+        return d
+
+    def test_positive_pnl(self, capsys):
+        notify.weekly_summary(self._base(weekly_pnl=100.0))
+        assert "📈" in capsys.readouterr().out
+
+    def test_negative_pnl(self, capsys):
+        notify.weekly_summary(self._base(weekly_pnl=-100.0))
+        assert "📉" in capsys.readouterr().out
+
+
+# ── monthly_summary ──────────────────────────────────────────
+
+class TestMonthlySummary:
+    def _base(self, **overrides):
+        d = {
+            'month': '2026-04', 'equity': 5200.0, 'monthly_pnl': 200.0,
+            'monthly_pnl_pct': 4.0, 'peak_equity': 5200.0, 'max_dd_month': 2.0,
+            'total_trades': 20, 'winners': 15, 'losers': 5,
+            'win_rate': 75.0, 'total_fees': 0.0, 'total_llm_cost': 0.05,
+            'instrument_performance': [],
+            'universe_changes': [],
+        }
+        d.update(overrides)
+        return d
+
+    def test_positive_pnl(self, capsys):
+        notify.monthly_summary(self._base(monthly_pnl=200.0))
+        assert "📈" in capsys.readouterr().out
+
+    def test_negative_pnl(self, capsys):
+        notify.monthly_summary(self._base(monthly_pnl=-200.0))
+        assert "📉" in capsys.readouterr().out
+
+    def test_instrument_all_three_pnl_emojis(self, capsys):
+        instruments = [
+            {'symbol': 'SPY', 'trades': 5, 'pnl': 100.0, 'pnl_pct': 2.0},   # profit → ✅
+            {'symbol': 'QQQ', 'trades': 3, 'pnl': -50.0, 'pnl_pct': -1.0},  # loss   → ❌
+            {'symbol': 'IWM', 'trades': 2, 'pnl': 0.0,   'pnl_pct': 0.0},   # zero   → ➖
+        ]
+        notify.monthly_summary(self._base(instrument_performance=instruments))
+        out = capsys.readouterr().out
+        assert "✅" in out
+        assert "❌" in out
+        assert "➖" in out
+
+    def test_universe_changes_present(self, capsys):
+        notify.monthly_summary(self._base(universe_changes=["Added NVDA T1", "Removed IWM T3"]))
+        assert "Universe changes" in capsys.readouterr().out
+
+    def test_universe_changes_absent(self, capsys):
+        notify.monthly_summary(self._base(universe_changes=[]))
+        assert "Universe changes" not in capsys.readouterr().out
+
+
+# ── critical_alert ───────────────────────────────────────────
+
+class TestCriticalAlert:
+    def test_sends_urgency_message(self, capsys):
+        notify.critical_alert("RULE 1 VIOLATION")
+        out = capsys.readouterr().out
+        assert "CRITICAL ALERT" in out
+        assert "RULE 1 VIOLATION" in out
+
+
+# ── drawdown_alert ───────────────────────────────────────────
+
+class TestDrawdownAlert:
+    def test_includes_drawdown_and_action(self, capsys):
+        notify.drawdown_alert(15.5, "Disabled Tier 2+")
+        out = capsys.readouterr().out
+        assert "15.5" in out
+        assert "Disabled Tier 2+" in out
+
+
+# ── universe_update ──────────────────────────────────────────
+
+class TestUniverseUpdate:
+    def test_with_changes(self, capsys):
+        notify.universe_update(["Added AAPL", "Removed GLD"], total_instruments=18)
+        out = capsys.readouterr().out
+        assert "Added AAPL" in out
+        assert "18" in out
+
+    def test_empty_changes(self, capsys):
+        notify.universe_update([], total_instruments=17)
+        out = capsys.readouterr().out
+        assert "17" in out


### PR DESCRIPTION
## Summary

- 30 tests across all 8 indicator functions + `compute_all_daily`
- Hits every branch: insufficient-data early returns, RSI `avg_loss==0` at seed and in Wilder loop, ATR true-range all three cases, ADX flat-bar path (`atr_smooth==0` → `pdi=mdi=0` → `di_sum==0`), MACD `first_valid==None` and not-enough-for-signal, VWAP/rvol zero-denominator NaN paths
- Adds `# pragma: no cover` to the `__main__` self-test block
- Adds `pyproject.toml` with `testpaths = ["skills", "scripts"]` and coverage config (supersedes `feat/coverage-coveralls` if that merges first)

## Test plan

- [ ] `PYTHONPATH=scripts pytest scripts/test_indicators.py --cov=indicators --cov-report=term-missing` → 100% on `indicators.py`
- [ ] `PYTHONPATH=scripts pytest` → all 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)