### PR TITLE
feat: scripts/reconcile.py — Redis ↔ Alpaca position reconciliation

### DIFF
--- a/docs/FEATURE_WISHLIST.md
+++ b/docs/FEATURE_WISHLIST.md
@@ -9,17 +9,18 @@ System context: RSI-2 mean reversion, 5 agents, Redis pub/sub, Phoenix LiveView 
 
 These are known issues documented in HANDOFF.md that can cause real harm.
 
-- [ ] **Executor: sell fill race condition** — `execute_sell` assumes fills are immediate. If market is closed, order sits ACCEPTED but executor records fake P&L, removes position from Redis, and cancels stop-loss before actual execution. Fix: gate all post-fill logic on `filled_order.status == "filled"`.
-- [ ] **Executor: accept qty=0 orders** — PM can send qty=0 when regime reduction + small account + rounding. Executor submits to Alpaca (rejected), then logs a fake fill and saves a qty=0 position to Redis. Fix: reject `quantity <= 0` at top of `execute_buy` and `execute_sell`.
-- [ ] **Watcher/PM feedback loop on qty=0 positions** — A qty=0 Redis position triggers: watcher exit → PM approve → executor fail → watcher entry → repeat forever. Fix: PM checks for existing position before approving entry; executor deletes qty≤0 positions as cleanup.
-- [ ] **Executor: submits equity market orders after market close** — 4:15 PM screener generates signals that produce orders. These fill at next open at unknown price. Fix: check `tc.get_clock().is_open` before submitting equity orders.
+- [x] **Executor: sell fill race condition** — `stop_cancelled` flag + stop-loss restore in exception handler. PR #57.
+- [x] **Executor: accept qty=0 orders** — Both `execute_buy` and `execute_sell` now reject `quantity <= 0`. PR #57.
+- [x] **Watcher/PM feedback loop on qty=0 positions** — PM dedup check rejects entry when position exists in Redis (including qty=0). Verified by tests. PR #58.
+- [x] **PM: qty=0 order after DOWNTREND halving** — Guard added after halving step in `evaluate_entry_signal`. PR #58.
+- [x] **Executor: submits equity market orders after market close** — `clock.is_open` check in both `execute_buy` and `execute_sell`. PR #57.
 
 ---
 
 ## ✅ Quick Wins (Low Effort, High Value)
 
 ### Observability & Monitoring
-- [ ] **`scripts/reconcile.py`** — Compare Redis positions vs Alpaca actual positions. Identify missing stop-losses, phantom positions, mismatched quantities. Run on startup and daily. This is explicitly called out as needed in HANDOFF.md.
+- [x] **`scripts/reconcile.py`** — Compare Redis positions vs Alpaca actual positions. Identifies phantoms, orphans, qty mismatches, missing stops. Run with `--fix` to auto-resubmit stops. 100% test coverage. PR #59.
 - [ ] **Agent heartbeat dashboard panel** — Show last-seen time for each agent (screener, watcher, PM, executor, supervisor). Green/yellow/red status based on staleness. Supervisor already writes heartbeats to Redis; dashboard just needs to read them.
 - [ ] **Stale heartbeat alert** — If any agent heartbeat is >30min old during market hours, send Telegram critical alert. Currently health checks run but don't alert specifically on stale agents.
 - [ ] **Dashboard: current regime prominently displayed** — Show RANGING/UPTREND/DOWNTREND with ADX, +DI, -DI values and a colored badge. Currently data is in Redis but not prominently surfaced.
@@ -54,7 +55,7 @@ These are known issues documented in HANDOFF.md that can cause real harm.
 - [ ] **Intraday stop monitoring** — Currently watcher polls positions every 30 min. Add intraday check: if price has dropped X% from entry intraday, generate exit signal immediately without waiting for poll.
 - [ ] **Max daily loss limit** — In addition to drawdown circuit breakers (which are cumulative), add a single-day loss limit. If today's P&L exceeds -2%, halt new entries for the rest of the day.
 - [ ] **Position age alert** — If a position has been held >5 days without triggering time-stop (maybe stuck in a narrow range), send Telegram nudge for manual review.
-- [ ] **Correlated regime adjustment** — When regime is DOWNTREND, reduce position sizes automatically (e.g. half-size), even for Tier 1. Current code adjusts thresholds but not sizes.
+- [x] **Correlated regime adjustment** — DOWNTREND halves equity position sizes. Edge case where halving → 0 shares fixed (PR #58).
 
 ### Screener & Signal Quality
 - [ ] **Volume filter on entries** — Require minimum average daily volume for entry signals. Prevents entries on thin/illiquid days that can cause bad fills.
@@ -116,13 +117,13 @@ These are known issues documented in HANDOFF.md that can cause real harm.
 
 If picking 5 things to do next, in order:
 
-1. Fix the 4 known executor bugs (HANDOFF.md) — they can cause financial state corruption
-2. `scripts/reconcile.py` — catches state divergence before it compounds
-3. Heartbeat staleness alert — ensures you know when agents die
-4. Morning briefing Telegram message — high value, very low effort
-5. Weekly summary wiring — function exists, just needs a cron call
+1. ~~Fix the 5 known bugs (HANDOFF.md)~~ ✅ Done (PRs #57, #58)
+2. ~~`scripts/reconcile.py`~~ ✅ Done (PR #59)
+3. Stale heartbeat alert — if agent heartbeat >30min during market hours, Telegram critical alert
+4. Morning briefing Telegram message — 9:20 AM ET: regime, watchlist top 5, positions, drawdown
+5. Weekly summary wiring — `notify.weekly_summary()` exists, just needs a cron call in supervisor
 
 ---
 
 *Generated by examining all agent code, dashboard, config, notification module, and git history.*
-*Last updated: 2026-04-08*
+*Last updated: 2026-04-08. All critical bugs resolved. reconcile.py shipped. Coverage: config.py, indicators.py, notify.py, executor.py, reconcile.py all at 100% (168 tests).*

--- a/scripts/reconcile.py
+++ b/scripts/reconcile.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+reconcile.py — Redis ↔ Alpaca Position Reconciliation
+
+Compares Redis positions (trading:positions) against actual Alpaca positions.
+Identifies and optionally fixes:
+  - Phantom positions: in Redis but not on Alpaca
+  - Orphan positions: on Alpaca but not in Redis
+  - Quantity mismatches: Redis qty ≠ Alpaca qty
+  - Missing stop-losses: Redis position has no active GTC stop on Alpaca
+
+Usage (from repo root, after source ~/.trading_env):
+    PYTHONPATH=scripts python3 scripts/reconcile.py           # report only
+    PYTHONPATH=scripts python3 scripts/reconcile.py --fix     # report + fix missing stops
+"""
+
+import json
+import sys
+import argparse
+
+from alpaca.trading.client import TradingClient
+from alpaca.trading.requests import StopOrderRequest
+from alpaca.trading.enums import OrderSide, TimeInForce
+
+import config
+from config import Keys, get_redis, is_crypto
+
+_ACTIVE_STOP_STATUSES = {"new", "accepted", "pending_new"}
+
+
+# ── Data Loading ─────────────────────────────────────────────
+
+def load_redis_positions(r) -> dict:
+    """Return Redis positions dict (keyed by symbol)."""
+    raw = r.get(Keys.POSITIONS)
+    return json.loads(raw) if raw else {}
+
+
+def load_alpaca_positions(trading_client) -> dict:
+    """Return Alpaca positions dict keyed by symbol."""
+    alpaca_list = trading_client.get_all_positions()
+    return {p.symbol: p for p in alpaca_list}
+
+
+# ── Comparison ───────────────────────────────────────────────
+
+def reconcile_positions(redis_pos: dict, alpaca_pos: dict) -> list:
+    """
+    Compare Redis and Alpaca positions. Returns list of issue dicts, each with:
+      type: 'phantom' | 'orphan' | 'qty_mismatch'
+      symbol: str
+      + type-specific fields
+    """
+    issues = []
+
+    for symbol, pos in redis_pos.items():
+        if symbol not in alpaca_pos:
+            issues.append({"type": "phantom", "symbol": symbol, "pos": pos})
+        else:
+            redis_qty = int(pos["quantity"]) if not is_crypto(symbol) else float(pos["quantity"])
+            alpaca_qty = int(float(alpaca_pos[symbol].qty))
+            if redis_qty != alpaca_qty:
+                issues.append({
+                    "type": "qty_mismatch",
+                    "symbol": symbol,
+                    "redis_qty": redis_qty,
+                    "alpaca_qty": alpaca_qty,
+                    "pos": pos,
+                })
+
+    for symbol, ap in alpaca_pos.items():
+        if symbol not in redis_pos:
+            issues.append({"type": "orphan", "symbol": symbol, "alpaca_pos": ap})
+
+    return issues
+
+
+def check_stop_losses(trading_client, redis_pos: dict) -> list:
+    """
+    For each Redis position, verify an active GTC stop-loss exists on Alpaca.
+    Returns list of missing_stop issue dicts.
+    """
+    issues = []
+
+    for symbol, pos in redis_pos.items():
+        stop_order_id = pos.get("stop_order_id")
+        if not stop_order_id:
+            issues.append({"type": "missing_stop", "symbol": symbol, "pos": pos,
+                           "reason": "no stop_order_id in Redis"})
+            continue
+
+        try:
+            stop_order = trading_client.get_order_by_id(stop_order_id)
+            if stop_order.status not in _ACTIVE_STOP_STATUSES:
+                issues.append({"type": "missing_stop", "symbol": symbol, "pos": pos,
+                               "reason": f"stop status={stop_order.status}"})
+        except Exception as e:
+            issues.append({"type": "missing_stop", "symbol": symbol, "pos": pos,
+                           "reason": f"order not found: {e}"})
+
+    return issues
+
+
+# ── Fixes ────────────────────────────────────────────────────
+
+def fix_missing_stops(trading_client, r, stop_issues: list):
+    """Submit new GTC stop-loss orders for positions missing one. Updates Redis."""
+    if not stop_issues:
+        return
+
+    positions = load_redis_positions(r)
+
+    for issue in stop_issues:
+        symbol = issue["symbol"]
+        pos = issue["pos"]
+        qty = pos["quantity"]
+        stop_price = pos["stop_price"]
+
+        try:
+            req = StopOrderRequest(
+                symbol=symbol,
+                qty=int(qty) if not is_crypto(symbol) else qty,
+                side=OrderSide.SELL,
+                stop_price=round(float(stop_price), 2),
+                time_in_force=TimeInForce.GTC,
+            )
+            stop_order = trading_client.submit_order(req)
+            print(f"  ✅ Stop-loss placed for {symbol}: {stop_order.id} @ ${stop_price:.2f}")
+
+            if symbol in positions:
+                positions[symbol]["stop_order_id"] = str(stop_order.id)
+                r.set(Keys.POSITIONS, json.dumps(positions))
+
+        except Exception as e:
+            print(f"  ❌ Failed to place stop-loss for {symbol}: {e}")
+
+
+# ── Reporting ────────────────────────────────────────────────
+
+def print_report(pos_issues: list, stop_issues: list):
+    """Print a human-readable reconciliation report."""
+    total = len(pos_issues) + len(stop_issues)
+
+    print("\n[Reconcile] ══════════════════════════════════════")
+
+    if total == 0:
+        print("  ✅ All clear — Redis and Alpaca are in sync, all stop-losses active")
+        print("[Reconcile] ══════════════════════════════════════\n")
+        return
+
+    phantoms  = [i for i in pos_issues if i["type"] == "phantom"]
+    orphans   = [i for i in pos_issues if i["type"] == "orphan"]
+    mismatches = [i for i in pos_issues if i["type"] == "qty_mismatch"]
+
+    if phantoms:
+        print(f"\n  ⚠️  PHANTOM positions ({len(phantoms)}) — in Redis, not on Alpaca:")
+        for i in phantoms:
+            p = i.get("pos", {})
+            print(f"    {i['symbol']}: qty={p.get('quantity')}, entry=${p.get('entry_price')}")
+
+    if orphans:
+        print(f"\n  ⚠️  ORPHAN positions ({len(orphans)}) — on Alpaca, not in Redis:")
+        for i in orphans:
+            ap = i.get("alpaca_pos")
+            qty = getattr(ap, "qty", "?")
+            print(f"    {i['symbol']}: qty={qty}")
+
+    if mismatches:
+        print(f"\n  ⚠️  QTY MISMATCHES ({len(mismatches)}):")
+        for i in mismatches:
+            print(f"    {i['symbol']}: Redis={i['redis_qty']}, Alpaca={i['alpaca_qty']}")
+
+    if stop_issues:
+        print(f"\n  🚨 MISSING STOP-LOSSES ({len(stop_issues)}):")
+        for i in stop_issues:
+            print(f"    {i['symbol']}: {i.get('reason', '')}")
+
+    print(f"\n  Total issues: {total}")
+    print("[Reconcile] ══════════════════════════════════════\n")
+
+
+# ── Main ─────────────────────────────────────────────────────
+
+def main():  # pragma: no cover
+    parser = argparse.ArgumentParser(description="Redis ↔ Alpaca reconciliation")
+    parser.add_argument("--fix", action="store_true", help="Fix missing stop-losses automatically")
+    args = parser.parse_args()
+
+    r = get_redis()
+    trading_client = TradingClient(
+        config.ALPACA_API_KEY, config.ALPACA_SECRET_KEY, paper=config.PAPER_TRADING
+    )
+
+    print("[Reconcile] Loading positions...")
+    redis_pos = load_redis_positions(r)
+    alpaca_pos = load_alpaca_positions(trading_client)
+
+    print(f"  Redis: {len(redis_pos)} position(s)")
+    print(f"  Alpaca: {len(alpaca_pos)} position(s)")
+
+    pos_issues = reconcile_positions(redis_pos, alpaca_pos)
+    stop_issues = check_stop_losses(trading_client, redis_pos)
+
+    print_report(pos_issues, stop_issues)
+
+    if args.fix and stop_issues:
+        print("[Reconcile] Fixing missing stop-losses...")
+        fix_missing_stops(trading_client, r, stop_issues)
+    elif stop_issues and not args.fix:
+        print("[Reconcile] Run with --fix to automatically resubmit missing stop-losses.")
+
+    if pos_issues:
+        print("[Reconcile] ⚠️  Phantom/orphan/mismatch issues require manual review.")
+
+    return len(pos_issues) + len(stop_issues)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+
+# v1.0.0

--- a/scripts/test_reconcile.py
+++ b/scripts/test_reconcile.py
@@ -1,0 +1,303 @@
+"""
+Tests for reconcile.py — 100% coverage target.
+
+Run from repo root:
+    PYTHONPATH=scripts pytest scripts/test_reconcile.py -v
+"""
+import json
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, "scripts")
+
+# Mock alpaca and redis before import
+for mod in [
+    "alpaca", "alpaca.trading", "alpaca.trading.client",
+    "alpaca.trading.requests", "alpaca.trading.enums", "redis",
+]:
+    sys.modules[mod] = MagicMock()
+
+import alpaca.trading.enums as _enums
+_enums.OrderSide.SELL = "sell"
+_enums.TimeInForce.GTC = "gtc"
+_enums.QueryOrderStatus.OPEN = "open"
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+def make_redis_pos(symbol="SPY", qty=10, entry=500.0, stop=490.0, stop_order_id="stop-1"):
+    return {
+        "symbol": symbol,
+        "quantity": qty,
+        "entry_price": entry,
+        "entry_date": "2026-04-01",
+        "stop_price": stop,
+        "strategy": "RSI2",
+        "tier": 1,
+        "order_id": "ord-1",
+        "stop_order_id": stop_order_id,
+        "value": round(entry * qty, 2),
+        "unrealized_pnl_pct": 0.0,
+    }
+
+
+def make_alpaca_pos(symbol="SPY", qty="10", avg_entry="500.0"):
+    p = MagicMock()
+    p.symbol = symbol
+    p.qty = qty
+    p.avg_entry_price = avg_entry
+    return p
+
+
+def make_redis(positions: dict = None, store: dict = None):
+    base = {
+        "trading:positions": json.dumps(positions or {}),
+        "trading:simulated_equity": "5000.0",
+    }
+    if store:
+        base.update(store)
+    r = MagicMock()
+    r.get = lambda k: base.get(k)
+    r.set = MagicMock()
+    return r, base
+
+
+def make_stop_order(status="new"):
+    o = MagicMock()
+    o.status = status
+    return o
+
+
+# ── load_redis_positions ─────────────────────────────────────
+
+class TestLoadRedisPositions:
+    def test_returns_dict_from_redis(self):
+        pos = {"SPY": make_redis_pos()}
+        r, _ = make_redis(pos)
+        from reconcile import load_redis_positions
+        result = load_redis_positions(r)
+        assert result["SPY"]["symbol"] == "SPY"
+
+    def test_empty_when_key_missing(self):
+        r, _ = make_redis({})
+        from reconcile import load_redis_positions
+        result = load_redis_positions(r)
+        assert result == {}
+
+
+# ── load_alpaca_positions ────────────────────────────────────
+
+class TestLoadAlpacaPositions:
+    def test_returns_dict_keyed_by_symbol(self):
+        tc = MagicMock()
+        tc.get_all_positions.return_value = [
+            make_alpaca_pos("SPY", "10"),
+            make_alpaca_pos("QQQ", "5"),
+        ]
+        from reconcile import load_alpaca_positions
+        result = load_alpaca_positions(tc)
+        assert "SPY" in result
+        assert "QQQ" in result
+        assert result["SPY"].qty == "10"
+
+    def test_empty_when_no_positions(self):
+        tc = MagicMock()
+        tc.get_all_positions.return_value = []
+        from reconcile import load_alpaca_positions
+        result = load_alpaca_positions(tc)
+        assert result == {}
+
+
+# ── reconcile_positions ──────────────────────────────────────
+
+class TestReconcilePositions:
+    def test_phantom_in_redis_not_alpaca(self):
+        redis_pos = {"SPY": make_redis_pos("SPY")}
+        alpaca_pos = {}
+        from reconcile import reconcile_positions
+        issues = reconcile_positions(redis_pos, alpaca_pos)
+        phantoms = [i for i in issues if i["type"] == "phantom"]
+        assert len(phantoms) == 1
+        assert phantoms[0]["symbol"] == "SPY"
+
+    def test_orphan_in_alpaca_not_redis(self):
+        redis_pos = {}
+        alpaca_pos = {"QQQ": make_alpaca_pos("QQQ")}
+        from reconcile import reconcile_positions
+        issues = reconcile_positions(redis_pos, alpaca_pos)
+        orphans = [i for i in issues if i["type"] == "orphan"]
+        assert len(orphans) == 1
+        assert orphans[0]["symbol"] == "QQQ"
+
+    def test_qty_mismatch(self):
+        redis_pos = {"SPY": make_redis_pos("SPY", qty=10)}
+        alpaca_pos = {"SPY": make_alpaca_pos("SPY", qty="8")}
+        from reconcile import reconcile_positions
+        issues = reconcile_positions(redis_pos, alpaca_pos)
+        mismatches = [i for i in issues if i["type"] == "qty_mismatch"]
+        assert len(mismatches) == 1
+        assert mismatches[0]["redis_qty"] == 10
+        assert mismatches[0]["alpaca_qty"] == 8
+
+    def test_no_issues_when_in_sync(self):
+        redis_pos = {"SPY": make_redis_pos("SPY", qty=10)}
+        alpaca_pos = {"SPY": make_alpaca_pos("SPY", qty="10")}
+        from reconcile import reconcile_positions
+        issues = reconcile_positions(redis_pos, alpaca_pos)
+        assert issues == []
+
+    def test_multiple_symbols_mixed(self):
+        redis_pos = {
+            "SPY": make_redis_pos("SPY", qty=10),   # matched
+            "QQQ": make_redis_pos("QQQ", qty=5),    # phantom (not in Alpaca)
+        }
+        alpaca_pos = {
+            "SPY": make_alpaca_pos("SPY", qty="10"),
+            "IWM": make_alpaca_pos("IWM", qty="3"), # orphan
+        }
+        from reconcile import reconcile_positions
+        issues = reconcile_positions(redis_pos, alpaca_pos)
+        types = [i["type"] for i in issues]
+        assert "phantom" in types
+        assert "orphan" in types
+        assert "qty_mismatch" not in types
+
+
+# ── check_stop_losses ────────────────────────────────────────
+
+class TestCheckStopLosses:
+    def test_active_stop_no_issue(self):
+        pos = make_redis_pos(stop_order_id="stop-1")
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = make_stop_order(status="new")
+        from reconcile import check_stop_losses
+        issues = check_stop_losses(tc, {"SPY": pos})
+        assert issues == []
+
+    def test_accepted_stop_no_issue(self):
+        pos = make_redis_pos(stop_order_id="stop-1")
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = make_stop_order(status="accepted")
+        from reconcile import check_stop_losses
+        issues = check_stop_losses(tc, {"SPY": pos})
+        assert issues == []
+
+    def test_stop_order_not_found_raises_issue(self):
+        pos = make_redis_pos(stop_order_id="stop-gone")
+        tc = MagicMock()
+        tc.get_order_by_id.side_effect = Exception("not found")
+        from reconcile import check_stop_losses
+        issues = check_stop_losses(tc, {"SPY": pos})
+        missing = [i for i in issues if i["type"] == "missing_stop"]
+        assert len(missing) == 1
+        assert missing[0]["symbol"] == "SPY"
+
+    def test_stop_filled_or_cancelled_raises_issue(self):
+        pos = make_redis_pos(stop_order_id="stop-1")
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = make_stop_order(status="filled")
+        from reconcile import check_stop_losses
+        issues = check_stop_losses(tc, {"SPY": pos})
+        missing = [i for i in issues if i["type"] == "missing_stop"]
+        assert len(missing) == 1
+
+    def test_no_stop_order_id_raises_issue(self):
+        pos = make_redis_pos(stop_order_id=None)
+        tc = MagicMock()
+        from reconcile import check_stop_losses
+        issues = check_stop_losses(tc, {"SPY": pos})
+        missing = [i for i in issues if i["type"] == "missing_stop"]
+        assert len(missing) == 1
+
+    def test_multiple_positions_checked(self):
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = make_stop_order(status="new")
+        positions = {
+            "SPY": make_redis_pos("SPY", stop_order_id="s1"),
+            "QQQ": make_redis_pos("QQQ", stop_order_id="s2"),
+        }
+        from reconcile import check_stop_losses
+        issues = check_stop_losses(tc, positions)
+        assert issues == []
+        assert tc.get_order_by_id.call_count == 2
+
+
+# ── fix_missing_stops ────────────────────────────────────────
+
+class TestFixMissingStops:
+    def test_submits_stop_and_updates_redis(self):
+        pos = make_redis_pos("SPY", qty=10, stop=490.0)
+        r, store = make_redis({"SPY": pos})
+        issue = {"type": "missing_stop", "symbol": "SPY", "pos": pos}
+
+        stop_order = MagicMock()
+        stop_order.id = "new-stop-id"
+        tc = MagicMock()
+        tc.submit_order.return_value = stop_order
+
+        from reconcile import fix_missing_stops
+        fix_missing_stops(tc, r, [issue])
+
+        tc.submit_order.assert_called_once()
+        r.set.assert_called_once()
+        # Verify the saved positions contain updated stop_order_id
+        saved = json.loads(r.set.call_args[0][1])
+        assert saved["SPY"]["stop_order_id"] == "new-stop-id"
+
+    def test_no_issues_no_calls(self):
+        r, _ = make_redis({})
+        tc = MagicMock()
+        from reconcile import fix_missing_stops
+        fix_missing_stops(tc, r, [])
+        tc.submit_order.assert_not_called()
+        r.set.assert_not_called()
+
+    def test_submit_error_logged_not_raised(self):
+        pos = make_redis_pos("SPY")
+        r, _ = make_redis({"SPY": pos})
+        issue = {"type": "missing_stop", "symbol": "SPY", "pos": pos}
+        tc = MagicMock()
+        tc.submit_order.side_effect = Exception("API error")
+        from reconcile import fix_missing_stops
+        # Must not raise
+        fix_missing_stops(tc, r, [issue])
+
+
+# ── print_report ─────────────────────────────────────────────
+
+class TestPrintReport:
+    def test_clean_report_no_issues(self, capsys):
+        from reconcile import print_report
+        print_report([], [])
+        out = capsys.readouterr().out
+        assert "clean" in out.lower() or "no issues" in out.lower() or "✅" in out
+
+    def test_report_shows_phantom(self, capsys):
+        from reconcile import print_report
+        issues = [{"type": "phantom", "symbol": "SPY"}]
+        print_report(issues, [])
+        assert "phantom" in capsys.readouterr().out.lower() or "SPY" in capsys.readouterr().out
+
+    def test_report_shows_orphan(self, capsys):
+        from reconcile import print_report
+        issues = [{"type": "orphan", "symbol": "QQQ"}]
+        print_report(issues, [])
+        out = capsys.readouterr().out
+        assert "orphan" in out.lower() or "QQQ" in out
+
+    def test_report_shows_stop_issues(self, capsys):
+        from reconcile import print_report
+        pos = make_redis_pos()
+        stop_issues = [{"type": "missing_stop", "symbol": "SPY", "pos": pos}]
+        print_report([], stop_issues)
+        out = capsys.readouterr().out
+        assert "stop" in out.lower() or "SPY" in out
+
+    def test_report_shows_qty_mismatch(self, capsys):
+        from reconcile import print_report
+        issues = [{"type": "qty_mismatch", "symbol": "SPY", "redis_qty": 10, "alpaca_qty": 8}]
+        print_report(issues, [])
+        out = capsys.readouterr().out
+        assert "SPY" in out


### PR DESCRIPTION
## Summary
- New utility: `scripts/reconcile.py` compares Redis vs Alpaca positions
- Detects phantom positions (Redis has it, Alpaca doesn't), orphans (Alpaca has it, Redis doesn't), qty mismatches, and missing/inactive stop-losses
- `--fix` flag auto-resubmits missing GTC stop-losses and updates Redis
- 100% test coverage (23 tests in `scripts/test_reconcile.py`)
- Updates FEATURE_WISHLIST.md: all critical bugs and reconcile.py marked done

## Usage
```bash
PYTHONPATH=scripts python3 scripts/reconcile.py          # report only
PYTHONPATH=scripts python3 scripts/reconcile.py --fix    # fix missing stops
```

## Test plan
- [ ] `PYTHONPATH=scripts pytest scripts/test_reconcile.py -v` → 23 passed
- [ ] `PYTHONPATH=scripts pytest` → 168 passed, 0 failed
- [ ] Coverage: `reconcile.py` at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)