### PR TITLE
chore: add pre-commit hook blocking direct commits to main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Prevent direct commits to main or master.
+# All changes must go through a feature branch and PR.
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  echo "ERROR: Direct commits to '$branch' are not allowed."
+  echo "       Create a feature branch and open a PR instead."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `.githooks/pre-commit` that rejects commits when `HEAD` is `main` or `master`
- Hook is tracked in the repo so it survives clones
- New contributors activate with: `git config core.hooksPath .githooks`

## Test Plan
- [ ] Hook is in `.githooks/pre-commit` and executable
- [ ] `git config core.hooksPath .githooks` already set on this machine
- [ ] Direct commit to main now produces: `ERROR: Direct commits to 'main' are not allowed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)