### PR TITLE
fix(executor): reconcile Redis when Alpaca auto-triggers stop-loss

### DIFF
--- a/.remember/remember.md
+++ b/.remember/remember.md
@@ -1,20 +1,12 @@
 # Handoff
 
 ## State
-Implemented wishlist items #6 + #7 (dashboard heartbeat panel + regime display).
-PR #67 open: `feat/dashboard-heartbeat-regime`. 39 tests passing.
-Worktree at `.worktrees/feat/dashboard-heartbeat-regime`.
+Fixed stop-loss auto-trigger bug: when Alpaca fills a GTC stop server-side, executor now reconciles Redis instead of looping forever trying to sell a closed position. Added `_reconcile_stop_filled` helper, updated `execute_sell` and `verify_startup`. 63/63 tests passing on `feat/elixir-coverage` branch.
 
-## What shipped
-- Heartbeat panel: 5-column grid cards, stale=red, warn=amber, ok=gray
-- Regime card: colored left border (green/red/gray) + +DI/-DI row below ADX
-- Removed dead heartbeat_status/1 1-arity clauses
-
-## Next (wishlist order)
-8. Dashboard: open position cards — entry price, unrealized P&L, stop distance, tier (already partially implemented)
-9. Dashboard: trade history table — paginated from TimescaleDB
-10. Dashboard: whipsaw/cooldown indicator
+## Next
+1. Run `cpr` — commit + push + PR not yet done (user just asked)
+2. Manually clear the stuck Redis position on the VPS (or restart executor daemon — verify_startup will auto-reconcile)
 
 ## Context
-FEATURE_WISHLIST.md items 1-7 all ✅. Items 8-10 are all dashboard work.
-Main branch has spec+plan docs committed (docs/superpowers/specs/ and docs/superpowers/plans/).
+- patch target is `executor.exit_alert` not `notify.exit_alert` (executor uses `from notify import exit_alert`)
+- `test_stop_cancel_failure_stop_not_filled_proceeds_with_market_sell` replaced the old `test_stop_cancel_failure_proceeds` — needed side_effect list to separate stop-check call from fill-poll calls

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -67,6 +67,56 @@ def update_simulated_equity(r, pnl_dollar):
     return new_equity
 
 
+# ── Stop-Loss Reconciliation ────────────────────────────────
+
+def _reconcile_stop_filled(r, pos, positions, symbol):
+    """Clean up Redis when Alpaca auto-triggered a GTC stop-loss.
+
+    Call this when we detect the stop order is already 'filled' on Alpaca,
+    meaning the position was closed server-side without us knowing.  Updates
+    simulated equity at the stop price, removes the position from Redis, and
+    sends the exit notification.
+    """
+    quantity = pos["quantity"]
+    entry_price = pos["entry_price"]
+    fill_price = float(pos["stop_price"])
+
+    pnl_pct = (fill_price - entry_price) / entry_price * 100
+    pnl_dollar = (fill_price - entry_price) * quantity
+
+    if is_crypto(symbol):
+        fee = (entry_price * quantity + fill_price * quantity) * (config.BTC_FEE_RATE / 2)
+        pnl_dollar -= fee
+        pnl_pct -= (config.BTC_FEE_RATE * 100)
+
+    new_equity = update_simulated_equity(r, pnl_dollar)
+
+    del positions[symbol]
+    r.set(Keys.POSITIONS, json.dumps(positions))
+    r.delete(Keys.exit_signaled(symbol))
+
+    try:
+        entry_dt = datetime.strptime(pos["entry_date"], "%Y-%m-%d")
+        hold_days = (datetime.now() - entry_dt).days
+    except Exception:
+        hold_days = 0
+
+    exit_alert(
+        symbol=symbol,
+        quantity=quantity,
+        entry_price=entry_price,
+        exit_price=fill_price,
+        pnl_pct=round(pnl_pct, 2),
+        pnl_dollar=round(pnl_dollar, 2),
+        exit_reason="stop_loss_auto",
+        hold_days=hold_days,
+    )
+
+    print(f"  [Executor] ❌ STOP-LOSS AUTO-TRIGGERED: {symbol} @ ${fill_price:.2f}, "
+          f"P&L {pnl_pct:+.2f}% (${pnl_dollar:+.2f}), equity now ${new_equity:.2f}")
+    return True
+
+
 # ── Safety Validation ───────────────────────────────────────
 
 def validate_order(r, order, account):
@@ -317,8 +367,16 @@ def execute_sell(r, trading_client, order):
                 print(f"  [Executor] Cancelled stop-loss {stop_order_id} for {symbol}")
                 time.sleep(1)  # let cancellation settle before submitting sell
             except Exception as cancel_err:
-                # Already triggered/cancelled — proceed; the position may have
-                # been stopped out and we just haven't synced Redis yet.
+                # Check if Alpaca already filled the stop (position closed server-side).
+                # If so, reconcile Redis and return — no market sell needed.
+                try:
+                    stop_check = trading_client.get_order_by_id(stop_order_id)
+                    if stop_check.status == "filled":
+                        print(f"  [Executor] Stop-loss for {symbol} was triggered by Alpaca — reconciling")
+                        return _reconcile_stop_filled(r, pos, positions, symbol)
+                except Exception:
+                    pass
+                # Stop not filled or unreachable — proceed with market sell attempt.
                 print(f"  [Executor] ⚠️ Could not cancel stop-loss for {symbol}: {cancel_err}")
 
         # Step 2: Submit the market sell
@@ -529,6 +587,7 @@ def verify_startup(trading_client, r):
     positions = json.loads(r.get(Keys.POSITIONS) or "{}")
     if positions:
         print(f"  Checking {len(positions)} open position(s)...")
+        stop_filled_syms = []
         for sym, pos in positions.items():
             stop_id = pos.get("stop_order_id")
             if stop_id:
@@ -536,9 +595,12 @@ def verify_startup(trading_client, r):
                     stop_order = trading_client.get_order_by_id(stop_id)
                     if stop_order.status in ("new", "accepted", "pending_new"):
                         print(f"    ✅ {sym}: stop-loss active @ ${pos['stop_price']}")
+                    elif stop_order.status == "filled":
+                        print(f"    ⚠️  {sym}: stop-loss filled by Alpaca — will reconcile")
+                        stop_filled_syms.append(sym)
                     else:
                         print(f"    ⚠️  {sym}: stop-loss status={stop_order.status}")
-                except:
+                except Exception:
                     print(f"    ❌ {sym}: stop-loss order not found — resubmitting")
                     submit_stop_loss(trading_client, sym, pos["quantity"], pos["stop_price"])
             else:
@@ -546,6 +608,9 @@ def verify_startup(trading_client, r):
                 new_stop_id = submit_stop_loss(trading_client, sym, pos["quantity"], pos["stop_price"])
                 pos["stop_order_id"] = new_stop_id
                 r.set(Keys.POSITIONS, json.dumps(positions))
+        # Reconcile any positions that Alpaca closed via stop-loss
+        for sym in stop_filled_syms:
+            _reconcile_stop_filled(r, positions[sym], positions, sym)
     else:
         print(f"  ✅ No open positions")
 

--- a/skills/executor/test_executor.py
+++ b/skills/executor/test_executor.py
@@ -710,15 +710,18 @@ class TestExecuteSell:
             result = execute_sell(r, tc, make_sell_signal())
         assert result is False
 
-    def test_stop_cancel_failure_proceeds(self):
-        """If cancel_order_by_id raises (stop already triggered), proceed with sell."""
+    def test_stop_cancel_failure_stop_not_filled_proceeds_with_market_sell(self):
+        """If cancel raises and stop is not 'filled', proceed with market sell."""
         pos = make_position()
         r, store = make_redis({"SPY": pos})
 
-        filled = MagicMock()
-        filled.status = "filled"
-        filled.filled_avg_price = "505.00"
-        filled.filled_qty = "10"
+        stop_check = MagicMock()
+        stop_check.status = "cancelled"  # stop not filled → proceed to market sell
+
+        fill_poll = MagicMock()
+        fill_poll.status = "filled"
+        fill_poll.filled_avg_price = "505.00"
+        fill_poll.filled_qty = "10"
         submitted = MagicMock()
         submitted.id = "ord-1"
 
@@ -726,13 +729,64 @@ class TestExecuteSell:
         tc.get_clock.return_value = make_clock(is_open=True)
         tc.cancel_order_by_id.side_effect = Exception("already triggered")
         tc.submit_order.return_value = submitted
-        tc.get_order_by_id.return_value = filled
+        # First call: stop-status check → cancelled; subsequent calls: fill poll → filled
+        tc.get_order_by_id.side_effect = [stop_check] + [fill_poll] * 5
 
         with patch("time.sleep"), patch("notify.exit_alert"):
             from executor import execute_sell
             result = execute_sell(r, tc, make_sell_signal())
-        # stop_cancelled stays False → no stop restore in exception (if sell succeeds, fine)
         assert result is True
+        tc.submit_order.assert_called_once()  # market sell was submitted
+
+    def test_stop_already_filled_by_alpaca_reconciles_redis_without_market_sell(self):
+        """When Alpaca auto-triggers stop-loss, executor reconciles Redis without attempting market sell."""
+        pos = make_position(qty=10, entry=500.0, stop=490.0, stop_order_id="stop-456")
+        r, store = make_redis({"SPY": pos})
+
+        stop_order = MagicMock()
+        stop_order.status = "filled"
+
+        tc = MagicMock()
+        tc.get_clock.return_value = make_clock(is_open=True)
+        tc.cancel_order_by_id.side_effect = Exception("order is not cancelable")
+        tc.get_order_by_id.return_value = stop_order
+
+        with patch("time.sleep"), patch("executor.exit_alert") as mock_alert:
+            from executor import execute_sell
+            result = execute_sell(r, tc, make_sell_signal())
+
+        assert result is True
+        # Position removed from Redis
+        assert "SPY" not in json.loads(store["trading:positions"])
+        # No market sell attempted
+        tc.submit_order.assert_not_called()
+        # Equity updated at stop price: pnl = (490 - 500) * 10 = -100 → equity = 4900
+        assert float(store["trading:simulated_equity"]) == pytest.approx(4900.0)
+        # Notification sent
+        mock_alert.assert_called_once()
+        call_kwargs = mock_alert.call_args[1]
+        assert call_kwargs["symbol"] == "SPY"
+        assert call_kwargs["exit_price"] == pytest.approx(490.0)
+
+    def test_stop_already_filled_clears_exit_signaled_flag(self):
+        """Reconciling a stop-filled position clears the exit_signaled Redis key."""
+        pos = make_position(stop_order_id="stop-456")
+        r, store = make_redis({"SPY": pos})
+        r.delete = MagicMock()
+
+        stop_order = MagicMock()
+        stop_order.status = "filled"
+
+        tc = MagicMock()
+        tc.get_clock.return_value = make_clock(is_open=True)
+        tc.cancel_order_by_id.side_effect = Exception("already triggered")
+        tc.get_order_by_id.return_value = stop_order
+
+        with patch("time.sleep"), patch("executor.exit_alert"):
+            from executor import execute_sell
+            execute_sell(r, tc, make_sell_signal())
+
+        r.delete.assert_called_once_with("trading:exit_signaled:SPY")
 
 
 # ── TestCancelExistingOrders ─────────────────────────────────
@@ -918,6 +972,25 @@ class TestVerifyStartup:
         from executor import verify_startup
         verify_startup(tc, r)
         tc.submit_order.assert_called_once()
+
+    def test_position_with_filled_stop_reconciles_redis(self):
+        """When stop order is 'filled' at startup, position removed from Redis and equity updated."""
+        pos = make_position(qty=10, entry=500.0, stop=490.0, stop_order_id="stop-456")
+        r, store = make_redis({"SPY": pos})
+        r.delete = MagicMock()
+
+        tc = self._make_tc(stop_status="filled")
+
+        with patch("executor.exit_alert") as mock_alert:
+            from executor import verify_startup
+            verify_startup(tc, r)
+
+        # Position removed
+        assert "SPY" not in json.loads(store["trading:positions"])
+        # Equity updated: pnl = (490 - 500) * 10 = -100
+        assert float(store["trading:simulated_equity"]) == pytest.approx(4900.0)
+        # Notification sent
+        mock_alert.assert_called_once()
 
     def test_checks_failed_exits(self):
         r, _ = make_redis({})


### PR DESCRIPTION
## Summary
- Adds `_reconcile_stop_filled` helper that cleans up a position Alpaca closed via stop: removes from Redis, updates simulated equity at stop price, sends exit notification
- `execute_sell` now detects a filled stop order when cancel fails and reconciles instead of attempting a doomed market sell (was causing infinite watcher → executor loop)
- `verify_startup` reconciles stop-filled positions found at daemon startup

## Root cause
When Alpaca auto-triggers a GTC stop, the position is gone from Alpaca but remains in Redis. Watcher generates exit signals every ~30min; executor tries to sell, fails, leaves Redis untouched → infinite loop of unfillable notifications.

## Test plan
- [ ] `PYTHONPATH=scripts python3 -m pytest skills/executor/test_executor.py -v` → 63 passed
- [ ] On VPS: restart executor daemon — `verify_startup` will auto-reconcile any stuck positions
- [ ] Confirm no more watcher notifications for the closed position

🤖 Generated with [Claude Code](https://claude.com/claude-code)