### PR TITLE
safety: cancelled stop auto-resubmit + daily loss circuit breaker fixes

### DIFF
--- a/docs/superpowers/plans/2026-04-10-cancelled-stop-daily-loss.md
+++ b/docs/superpowers/plans/2026-04-10-cancelled-stop-daily-loss.md
@@ -1,0 +1,641 @@
+# Cancelled Stop Auto-Resubmit + Daily Loss Circuit Breaker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (1) When a GTC stop-loss is unexpectedly cancelled by Alpaca, executor detects it, resubmits at the original stop price, and fires a critical alert. (2) When the daily loss limit is hit, a critical alert fires (not a silent drawdown alert), and sells are always allowed through regardless of daily halt status.
+
+**Architecture:** Feature 1 adds `_check_cancelled_stops(trading_client, r)` to executor, called on each idle daemon cycle. Feature 2 fixes two existing gaps: executor's `validate_order` currently blocks sells when daily P&L is breached (moves the check buy-only), and supervisor's daily loss CB uses `drawdown_alert` instead of `critical_alert`. Both features are independent and can be worked in any order.
+
+**Tech Stack:** Python, pytest, unittest.mock. All tests: `PYTHONPATH=scripts pytest <test_file> -v`. No new deps.
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `skills/executor/executor.py` | Add `_check_cancelled_stops`; fix `validate_order` to make daily loss check buy-only and add `daily_halt` to status guard |
+| `skills/executor/test_executor.py` | New: `TestCheckCancelledStops`, new `TestValidateOrder` cases |
+| `skills/supervisor/supervisor.py` | Change `drawdown_alert` → `critical_alert` in `run_circuit_breakers` daily loss block |
+| `skills/supervisor/test_supervisor.py` | Update `test_daily_loss_limit_halts` to patch `critical_alert` not `drawdown_alert` |
+
+---
+
+## Task 1: Fix executor `validate_order` — daily_halt + sell-through
+
+**Context:** `validate_order` (executor.py line 122) has two bugs when daily loss limit is hit:
+1. Line 127: status guard only checks `"halted"` — `"daily_halt"` does not block buys, so supervisor sets `daily_halt` but executor ignores it for buy rejection
+2. Lines 144-149: daily P&L check is outside the buy-only block, blocking sells too
+
+**Files:**
+- Modify: `skills/executor/executor.py:127,144-149`
+- Test: `skills/executor/test_executor.py`
+
+- [ ] **Step 1: Write three failing tests**
+
+Add to `class TestValidateOrder` in `skills/executor/test_executor.py`:
+
+```python
+def test_daily_halt_blocks_buy(self):
+    from executor import validate_order
+    r = self._r(status="daily_halt")
+    order = {"side": "buy", "quantity": 1, "entry_price": 10.0, "order_value": 10.0}
+    ok, reason = validate_order(r, order, make_account())
+    assert not ok
+    assert "daily_halt" in reason
+
+def test_daily_halt_allows_sell(self):
+    from executor import validate_order
+    pos = make_position()
+    r = self._r(positions={"SPY": pos}, status="daily_halt")
+    order = {"side": "sell", "symbol": "SPY"}
+    ok, _ = validate_order(r, order, make_account())
+    assert ok
+
+def test_daily_loss_limit_allows_sell(self):
+    from executor import validate_order
+    # equity=5000, DAILY_LOSS_LIMIT_PCT=0.03 → threshold=-150; pnl=-200 (breached)
+    pos = make_position()
+    r = self._r(positions={"SPY": pos}, daily_pnl="-200.0")
+    order = {"side": "sell", "symbol": "SPY"}
+    ok, _ = validate_order(r, order, make_account())
+    assert ok
+```
+
+- [ ] **Step 2: Run to confirm all three fail**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestValidateOrder::test_daily_halt_blocks_buy skills/executor/test_executor.py::TestValidateOrder::test_daily_halt_allows_sell skills/executor/test_executor.py::TestValidateOrder::test_daily_loss_limit_allows_sell -v
+```
+
+Expected: 3 FAILED
+
+- [ ] **Step 3: Fix `validate_order` in executor.py**
+
+Replace lines 125-149 (the system status guard + daily loss block):
+
+```python
+    # System status — blocks new entries, always allows exits
+    status = r.get(Keys.SYSTEM_STATUS)
+    if status in ("halted", "daily_halt") and order["side"] == "buy":
+        return False, f"System is {status} — no new entries"
+
+    # Rule 1: Never exceed simulated cash
+    if order["side"] == "buy":
+        sim_cash = get_simulated_cash(r)
+        order_value = order.get("order_value", order["quantity"] * order["entry_price"])
+        if order_value > sim_cash:
+            return False, f"Rule 1: Order ${order_value:.0f} > simulated cash ${sim_cash:.0f}"
+
+        # Daily loss limit belt-and-suspenders (supervisor sets daily_halt; this catches
+        # the gap between supervisor cron cycles). Skipped for forced orders.
+        if not order.get("force"):
+            daily_pnl = float(r.get(Keys.DAILY_PNL) or 0)
+            equity = get_simulated_equity(r)
+            if daily_pnl <= -(equity * config.DAILY_LOSS_LIMIT_PCT):
+                return False, f"Daily loss limit: ${daily_pnl:.2f}"
+```
+
+Note: the original code had `if not order.get("force"):` wrapping the daily_pnl check at the top level. The new code keeps `force` bypass but only for buys. The sell path is unaffected.
+
+- [ ] **Step 4: Run all three new tests plus the existing daily loss tests**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestValidateOrder -v
+```
+
+Expected: all PASS (including pre-existing `test_halted_blocks_buy`, `test_halted_allows_sell`, `test_daily_loss_limit_blocks`, `test_force_skips_daily_loss_limit`)
+
+- [ ] **Step 5: Run full executor test suite to catch regressions**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/executor/executor.py skills/executor/test_executor.py
+git commit -m "fix(executor): daily_halt blocks buys, allows sells; daily loss check buy-only"
+```
+
+---
+
+## Task 2: Fix supervisor — daily loss CB fires `critical_alert`
+
+**Context:** `run_circuit_breakers` in supervisor.py lines 101-110 already sets `daily_halt` and alerts, but uses `drawdown_alert` (a softer alert format). Should use `critical_alert`. The existing test `test_daily_loss_limit_halts` patches `drawdown_alert` — update it to patch `critical_alert`.
+
+**Files:**
+- Modify: `skills/supervisor/supervisor.py:106-109`
+- Test: `skills/supervisor/test_supervisor.py`
+
+- [ ] **Step 1: Write a failing test**
+
+Find `test_daily_loss_limit_halts` in `skills/supervisor/test_supervisor.py` (around line 292). Add a new test next to it:
+
+```python
+def test_daily_loss_limit_fires_critical_alert(self):
+    equity = 5000.0
+    daily_pnl = -(equity * _config.DAILY_LOSS_LIMIT_PCT) - 1
+    r = _make_cb(equity=equity, daily_pnl=daily_pnl, status="active")
+    with patch("supervisor.critical_alert") as mock_alert:
+        from supervisor import run_circuit_breakers
+        run_circuit_breakers(r)
+        mock_alert.assert_called_once()
+        msg = mock_alert.call_args[0][0]
+        assert "DAILY LOSS" in msg
+        assert str(round(daily_pnl, 2)) in msg or "halted" in msg.lower()
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+PYTHONPATH=scripts pytest skills/supervisor/test_supervisor.py::TestRunCircuitBreakers::test_daily_loss_limit_fires_critical_alert -v
+```
+
+Expected: FAILED (currently calls `drawdown_alert`, not `critical_alert`)
+
+- [ ] **Step 3: Fix supervisor.py**
+
+In `run_circuit_breakers`, replace the daily loss block (lines 101-110):
+
+```python
+    # Daily loss limit
+    daily_pnl = float(r.get(Keys.DAILY_PNL) or 0)
+    if daily_pnl <= -(equity * config.DAILY_LOSS_LIMIT_PCT):
+        if prev_status != "daily_halt":
+            r.set(Keys.SYSTEM_STATUS, "daily_halt")
+            critical_alert(
+                f"DAILY LOSS LIMIT HIT\n"
+                f"Today's P&L: ${daily_pnl:,.2f} "
+                f"(limit: {config.DAILY_LOSS_LIMIT_PCT * 100:.0f}% of equity)\n"
+                f"New entries halted until market open. Exits allowed."
+            )
+        return False
+```
+
+- [ ] **Step 4: Update the pre-existing `test_daily_loss_limit_halts` test**
+
+The existing test patches `supervisor.drawdown_alert` — change it to patch `supervisor.critical_alert` so it doesn't fail after the implementation change:
+
+```python
+def test_daily_loss_limit_halts(self):
+    equity = 5000.0
+    daily_pnl = -(equity * _config.DAILY_LOSS_LIMIT_PCT) - 1
+    r = _make_cb(equity=equity, daily_pnl=daily_pnl, status="active")
+    with patch("supervisor.critical_alert"):
+        from supervisor import run_circuit_breakers
+        result = run_circuit_breakers(r)
+    assert result is False
+    r.set.assert_any_call(Keys.SYSTEM_STATUS, "daily_halt")
+```
+
+- [ ] **Step 5: Run new test + updated test**
+
+```bash
+PYTHONPATH=scripts pytest skills/supervisor/test_supervisor.py::TestRunCircuitBreakers -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 6: Run full supervisor test suite**
+
+```bash
+PYTHONPATH=scripts pytest skills/supervisor/test_supervisor.py -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add skills/supervisor/supervisor.py skills/supervisor/test_supervisor.py
+git commit -m "fix(supervisor): daily loss CB fires critical_alert instead of drawdown_alert"
+```
+
+---
+
+## Task 3: Add `_check_cancelled_stops` — cancelled stop, position still on Alpaca
+
+**Context:** New function. When a stop is `cancelled` and the underlying position still exists on Alpaca, resubmit the stop at the original price, update Redis, and fire a critical alert. This is the most important case.
+
+**Files:**
+- Modify: `skills/executor/executor.py` (add function after `_reconcile_stop_filled`)
+- Test: `skills/executor/test_executor.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add a new test class to `skills/executor/test_executor.py`:
+
+```python
+# ── TestCheckCancelledStops ──────────────────────────────────
+
+class TestCheckCancelledStops:
+    def _make_stop_order(self, status="new", stop_id="stop-456"):
+        o = MagicMock()
+        o.id = stop_id
+        o.status = status
+        return o
+
+    def _make_alpaca_position(self, symbol="SPY"):
+        p = MagicMock()
+        p.symbol = symbol
+        return p
+
+    def test_cancelled_stop_position_exists_resubmits_and_alerts(self):
+        """Cancelled stop + position on Alpaca → resubmit + critical_alert."""
+        pos = make_position(symbol="SPY", qty=10, stop=490.0, stop_order_id="old-stop")
+        r, store = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = self._make_stop_order(status="cancelled")
+        tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+        new_stop = MagicMock()
+        new_stop.id = "new-stop-999"
+        tc.submit_order.return_value = new_stop
+
+        with patch("executor.critical_alert") as mock_alert:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        # Stop resubmitted
+        tc.submit_order.assert_called_once()
+
+        # Redis updated with new stop_order_id
+        saved = json.loads(store["trading:positions"])
+        assert saved["SPY"]["stop_order_id"] == "new-stop-999"
+
+        # Alert fired
+        mock_alert.assert_called_once()
+        assert "SPY" in mock_alert.call_args[0][0]
+        assert "RESUBMIT" in mock_alert.call_args[0][0].upper()
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestCheckCancelledStops::test_cancelled_stop_position_exists_resubmits_and_alerts -v
+```
+
+Expected: FAILED (`_check_cancelled_stops` not defined)
+
+- [ ] **Step 3: Add the function skeleton to executor.py**
+
+Insert after `_reconcile_stop_filled` (after line ~117, before `# ── Safety Validation ─`):
+
+```python
+# ── Runtime Stop Monitoring ──────────────────────────────────
+
+def _check_cancelled_stops(trading_client, r):
+    """Check all open positions for unexpectedly cancelled stop orders.
+
+    Called each idle daemon cycle. For each position with a stop_order_id:
+    - 'cancelled': verify position still on Alpaca, resubmit stop, alert
+    - 'filled':    delegate to _reconcile_stop_filled
+    - healthy:     skip
+    """
+    positions = json.loads(r.get(Keys.POSITIONS) or "{}")
+    if not positions:
+        return
+
+    # Fetch Alpaca positions once for the whole check
+    try:
+        alpaca_symbols = {p.symbol for p in trading_client.get_all_positions()}
+    except Exception as exc:
+        print(f"  [Executor] _check_cancelled_stops: could not fetch Alpaca positions: {exc}")
+        return
+
+    stop_filled_syms = []
+
+    for symbol, pos in list(positions.items()):
+        stop_id = pos.get("stop_order_id")
+        if not stop_id:
+            continue
+
+        try:
+            stop_order = trading_client.get_order_by_id(stop_id)
+        except Exception as exc:
+            print(f"  [Executor] _check_cancelled_stops: could not fetch stop {stop_id} for {symbol}: {exc}")
+            continue
+
+        if stop_order.status in ("new", "accepted", "pending_new"):
+            continue  # healthy
+
+        if stop_order.status == "filled":
+            stop_filled_syms.append(symbol)
+            continue
+
+        if stop_order.status == "cancelled":
+            if symbol not in alpaca_symbols:
+                # Position was closed externally — reconcile Redis
+                print(f"  [Executor] ⚠️  {symbol}: stop cancelled + position gone — cleaning Redis")
+                critical_alert(
+                    f"STOP CANCELLED — POSITION CLOSED EXTERNALLY: {symbol}\n"
+                    f"Stop {stop_id} was cancelled and position is gone from Alpaca.\n"
+                    f"Redis cleaned up. Review P&L manually."
+                )
+                positions.pop(symbol, None)
+                r.set(Keys.POSITIONS, json.dumps(positions))
+                continue
+
+            # Position still exists — resubmit stop
+            print(f"  [Executor] ⚠️  {symbol}: stop {stop_id} cancelled — resubmitting")
+            try:
+                new_stop_id = submit_stop_loss(
+                    trading_client, symbol, pos["quantity"], pos["stop_price"]
+                )
+                pos["stop_order_id"] = new_stop_id
+                r.set(Keys.POSITIONS, json.dumps(positions))
+                critical_alert(
+                    f"STOP CANCELLED & RESUBMITTED: {symbol}\n"
+                    f"Old stop {stop_id} was cancelled unexpectedly.\n"
+                    f"New stop {new_stop_id} placed @ ${pos['stop_price']:.2f}."
+                )
+                print(f"  [Executor] ✅ {symbol}: new stop {new_stop_id} placed @ ${pos['stop_price']:.2f}")
+            except Exception as exc:
+                critical_alert(
+                    f"STOP RESUBMIT FAILED — NAKED POSITION: {symbol}\n"
+                    f"Stop {stop_id} cancelled. Resubmit failed: {exc}\n"
+                    f"Manual intervention required immediately."
+                )
+                print(f"  [Executor] ❌ {symbol}: stop resubmit FAILED — {exc}")
+
+    # Reconcile any Alpaca-triggered stop fills found during check
+    for sym in stop_filled_syms:
+        _reconcile_stop_filled(r, positions[sym], positions, sym)
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestCheckCancelledStops::test_cancelled_stop_position_exists_resubmits_and_alerts -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add skills/executor/executor.py skills/executor/test_executor.py
+git commit -m "feat(executor): add _check_cancelled_stops — resubmit on cancel, position exists"
+```
+
+---
+
+## Task 4: `_check_cancelled_stops` — cancelled stop, position gone from Alpaca
+
+**Files:**
+- Test: `skills/executor/test_executor.py` (extend `TestCheckCancelledStops`)
+- No implementation changes needed — Task 3 already handles this path
+
+- [ ] **Step 1: Write failing test**
+
+Add to `TestCheckCancelledStops`:
+
+```python
+def test_cancelled_stop_position_gone_cleans_redis_and_alerts(self):
+    """Cancelled stop + position gone from Alpaca → clean Redis + critical_alert."""
+    pos = make_position(symbol="SPY", stop_order_id="old-stop")
+    r, store = make_redis({"SPY": pos})
+
+    tc = MagicMock()
+    tc.get_order_by_id.return_value = self._make_stop_order(status="cancelled")
+    tc.get_all_positions.return_value = []  # SPY not on Alpaca
+
+    with patch("executor.critical_alert") as mock_alert, \
+         patch("executor.submit_stop_loss") as mock_submit:
+        from executor import _check_cancelled_stops
+        _check_cancelled_stops(tc, r)
+
+    # No stop resubmitted
+    mock_submit.assert_not_called()
+
+    # Position removed from Redis
+    saved = json.loads(store["trading:positions"])
+    assert "SPY" not in saved
+
+    # Alert fired
+    mock_alert.assert_called_once()
+    assert "SPY" in mock_alert.call_args[0][0]
+    assert "EXTERNAL" in mock_alert.call_args[0][0].upper() or "GONE" in mock_alert.call_args[0][0].upper()
+```
+
+- [ ] **Step 2: Run to confirm it passes (implementation already covers this path)**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestCheckCancelledStops::test_cancelled_stop_position_gone_cleans_redis_and_alerts -v
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/executor/test_executor.py
+git commit -m "test(executor): cancelled stop + position gone → clean Redis + alert"
+```
+
+---
+
+## Task 5: `_check_cancelled_stops` — resubmit fails → naked position alert
+
+**Files:**
+- Test: `skills/executor/test_executor.py` (extend `TestCheckCancelledStops`)
+- No implementation changes needed — Task 3 already handles this path
+
+- [ ] **Step 1: Write failing test**
+
+Add to `TestCheckCancelledStops`:
+
+```python
+def test_cancelled_stop_resubmit_fails_fires_naked_position_alert(self):
+    """Cancelled stop + resubmit raises → critical NAKED POSITION alert, no Redis change."""
+    pos = make_position(symbol="SPY", stop_order_id="old-stop")
+    r, store = make_redis({"SPY": pos})
+
+    tc = MagicMock()
+    tc.get_order_by_id.return_value = self._make_stop_order(status="cancelled")
+    tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+    tc.submit_order.side_effect = RuntimeError("API timeout")
+
+    with patch("executor.critical_alert") as mock_alert:
+        from executor import _check_cancelled_stops
+        _check_cancelled_stops(tc, r)
+
+    # Alert fired with "NAKED" in message
+    mock_alert.assert_called_once()
+    assert "NAKED" in mock_alert.call_args[0][0]
+
+    # Redis not changed (stop_order_id unchanged)
+    saved = json.loads(store["trading:positions"])
+    assert saved["SPY"]["stop_order_id"] == "old-stop"
+```
+
+- [ ] **Step 2: Run to confirm it passes**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestCheckCancelledStops::test_cancelled_stop_resubmit_fails_fires_naked_position_alert -v
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/executor/test_executor.py
+git commit -m "test(executor): cancelled stop resubmit fail → NAKED POSITION alert"
+```
+
+---
+
+## Task 6: `_check_cancelled_stops` — filled, healthy, and no-positions cases
+
+**Files:**
+- Test: `skills/executor/test_executor.py` (extend `TestCheckCancelledStops`)
+
+- [ ] **Step 1: Write three tests**
+
+Add to `TestCheckCancelledStops`:
+
+```python
+def test_filled_stop_delegates_to_reconcile(self):
+    """Stop already filled by Alpaca → delegates to _reconcile_stop_filled."""
+    pos = make_position(symbol="SPY", stop_order_id="stop-456")
+    r, store = make_redis({"SPY": pos})
+
+    tc = MagicMock()
+    tc.get_order_by_id.return_value = self._make_stop_order(status="filled")
+    tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+
+    with patch("executor._reconcile_stop_filled") as mock_reconcile, \
+         patch("executor.critical_alert") as mock_alert:
+        from executor import _check_cancelled_stops
+        _check_cancelled_stops(tc, r)
+
+    mock_reconcile.assert_called_once()
+    mock_alert.assert_not_called()
+
+def test_healthy_stop_no_action(self):
+    """Stop status 'new' → no resubmit, no alert."""
+    pos = make_position(symbol="SPY", stop_order_id="stop-456")
+    r, _ = make_redis({"SPY": pos})
+
+    tc = MagicMock()
+    tc.get_order_by_id.return_value = self._make_stop_order(status="new")
+    tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+
+    with patch("executor.critical_alert") as mock_alert, \
+         patch("executor.submit_stop_loss") as mock_submit:
+        from executor import _check_cancelled_stops
+        _check_cancelled_stops(tc, r)
+
+    mock_submit.assert_not_called()
+    mock_alert.assert_not_called()
+
+def test_no_positions_returns_early(self):
+    """No open positions → no Alpaca calls at all."""
+    r, _ = make_redis({})
+    tc = MagicMock()
+
+    from executor import _check_cancelled_stops
+    _check_cancelled_stops(tc, r)
+
+    tc.get_all_positions.assert_not_called()
+    tc.get_order_by_id.assert_not_called()
+```
+
+- [ ] **Step 2: Run all three**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py::TestCheckCancelledStops -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/executor/test_executor.py
+git commit -m "test(executor): _check_cancelled_stops filled/healthy/no-positions cases"
+```
+
+---
+
+## Task 7: Wire into daemon_loop + full suite + final commit
+
+**Context:** `daemon_loop` is `# pragma: no cover` — we don't write tests for it, but we add the call there so it runs in production. Then run both full test suites and verify 100% coverage.
+
+**Files:**
+- Modify: `skills/executor/executor.py:673-678` (daemon_loop idle branch)
+
+- [ ] **Step 1: Add `_check_cancelled_stops` call in daemon_loop**
+
+In `daemon_loop`, find the idle branch (around line 676):
+
+```python
+        msg = pubsub.get_message(timeout=60)
+        if msg is None or msg['type'] != 'message':
+            continue
+```
+
+Change to:
+
+```python
+        msg = pubsub.get_message(timeout=60)
+        if msg is None or msg['type'] != 'message':
+            _check_cancelled_stops(trading_client, r)
+            continue
+```
+
+- [ ] **Step 2: Run full executor test suite**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 3: Run full supervisor test suite**
+
+```bash
+PYTHONPATH=scripts pytest skills/supervisor/test_supervisor.py -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 4: Run coverage for executor**
+
+```bash
+PYTHONPATH=scripts pytest skills/executor/test_executor.py --cov=executor --cov-report=term-missing
+```
+
+Expected: 100% (daemon_loop is pragma: no cover)
+
+- [ ] **Step 5: Run coverage for supervisor**
+
+```bash
+PYTHONPATH=scripts pytest skills/supervisor/test_supervisor.py --cov=supervisor --cov-report=term-missing
+```
+
+Expected: 100%
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add skills/executor/executor.py
+git commit -m "feat(executor): call _check_cancelled_stops on each idle daemon cycle"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec required sells to pass through on `daily_halt` — covered by `test_daily_halt_allows_sell` and `test_daily_loss_limit_allows_sell` (Task 1)
+- Spec required `critical_alert` not `drawdown_alert` for daily loss — covered (Task 2)
+- Spec required `reset_daily` to clear `daily_halt` — already implemented and tested (`test_re_enables_after_daily_halt` in supervisor tests); no changes needed
+- Spec required cancelled stop + position gone → reconcile Redis — covered (Task 4)
+- Spec required resubmit failure → naked position alert — covered (Task 5)
+- Spec required `stop_order_id is None` skip — covered by `if not stop_id: continue` in implementation, and implicitly by `test_no_positions_returns_early`
+- Spec said alert fires once — guarded by `prev_status != "daily_halt"` in supervisor (pre-existing, tested by `test_daily_loss_limit_halts`)

--- a/docs/superpowers/specs/2026-04-10-cancelled-stop-daily-loss-design.md
+++ b/docs/superpowers/specs/2026-04-10-cancelled-stop-daily-loss-design.md
@@ -1,0 +1,151 @@
+# Design: Cancelled Stop Auto-Resubmit + Daily Loss Circuit Breaker
+
+**Date:** 2026-04-10  
+**Status:** Approved  
+**Branch:** to be created from main
+
+---
+
+## Overview
+
+Two independent safety features:
+
+1. **Cancelled stop auto-resubmit** — executor detects when Alpaca cancels a GTC stop unexpectedly, resubmits at original stop price, alerts via Telegram.
+2. **Daily loss circuit breaker** — supervisor detects when same-day P&L exceeds configured threshold, sets `daily_halt` status, fires critical alert, allows exits but blocks new entries.
+
+---
+
+## Feature 1: Cancelled Stop Auto-Resubmit
+
+### Problem
+
+`_reconcile_stop_filled()` handles stops that Alpaca fills automatically. `verify_startup()` checks stop status at boot. Nothing monitors for stops that go `cancelled` during runtime — a corporate action, API glitch, or Alpaca maintenance window can silently cancel a GTC stop and leave a naked long position.
+
+### Design
+
+**Owner:** `executor.py` — only agent that touches Alpaca API.
+
+**New function:** `_check_cancelled_stops(trading_client, r)`
+
+Called at the end of each daemon cycle (after processing orders). Iterates all open positions in `trading:positions`. For each position with a `stop_order_id`:
+
+1. Fetch order from Alpaca via `trading_client.get_order_by_id(stop_order_id)`
+2. If status is `filled` — call existing `_reconcile_stop_filled()` and skip resubmit
+3. If status is `cancelled`:
+   a. Verify position still exists on Alpaca (`trading_client.get_all_positions()`)
+   b. If position gone — reconcile Redis (remove position, update equity at current/last price, alert)
+   c. If position exists — resubmit GTC stop at `pos["stop_price"]` via `submit_stop_loss()`
+   d. Update `stop_order_id` in Redis with new order ID
+   e. Fire `critical_alert(f"STOP CANCELLED & RESUBMITTED: {symbol} @ ${stop_price}")`
+   f. If resubmit raises exception — fire `critical_alert(f"STOP RESUBMIT FAILED: {symbol} — NAKED POSITION")` and leave (no retry)
+4. If status is `new` / `accepted` / `pending_new` — healthy, skip
+
+**Daemon loop integration:** Called once per cycle, after `process_approved_orders()`. Only runs if there are open positions (skip if `positions == {}`).
+
+**Rate limiting:** Alpaca allows ~200 req/min. At max 10 concurrent positions, 10 API calls per cycle. Daemon cycles every ~5s when idle — acceptable.
+
+### Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Stop `cancelled`, position exists | Resubmit + alert |
+| Stop `cancelled`, position gone | Reconcile Redis + alert |
+| Resubmit raises exception | Critical alert "NAKED POSITION", leave as-is |
+| `stop_order_id` is None | Skip (no stop to check) |
+| Alpaca API timeout on status check | Log warning, skip this cycle |
+
+### Testing
+
+- Unit test: stop `cancelled` + position exists → `submit_stop_loss` called, Redis updated, alert fired
+- Unit test: stop `cancelled` + position gone → Redis cleaned, alert fired
+- Unit test: stop `cancelled` + resubmit fails → critical alert "NAKED POSITION", no Redis change
+- Unit test: stop `filled` → delegates to `_reconcile_stop_filled`, no resubmit
+- Unit test: stop `new` → no action
+- Unit test: no open positions → function returns early, no API calls
+- Integration: confirm `_check_cancelled_stops` called in daemon loop
+
+---
+
+## Feature 2: Daily Loss Circuit Breaker
+
+### Problem
+
+`DAILY_LOSS_LIMIT_PCT` exists in config and executor already silently rejects new buys when daily P&L crosses it. Missing:
+- No Telegram alert fires — breach is invisible
+- No `trading:system_status` change — dashboard shows `active`
+- The silent reject blocks **sells** too (check is outside the buy-only branch) — trapped positions can't exit
+
+### Design
+
+**CB ownership:** `supervisor.py` → `run_circuit_breakers()` — consistent with existing drawdown CB pattern.
+
+**Executor fix:** Move the daily loss check inside the `if order["side"] == "buy":` block so sells always pass regardless of daily P&L.
+
+**Supervisor changes:**
+
+Add daily loss check to `run_circuit_breakers()`:
+
+```python
+daily_pnl = float(r.get(Keys.DAILY_PNL) or 0)
+equity = get_simulated_equity(r)
+daily_loss_limit = -(equity * config.DAILY_LOSS_LIMIT_PCT)
+
+if daily_pnl <= daily_loss_limit and prev_status != "daily_halt":
+    r.set(Keys.SYSTEM_STATUS, "daily_halt")
+    critical_alert(
+        f"DAILY LOSS LIMIT HIT\n"
+        f"Today's P&L: ${daily_pnl:,.2f} (limit: ${daily_loss_limit:,.2f})\n"
+        f"New entries halted until market open tomorrow. Exits allowed."
+    )
+```
+
+Alert fires **once** — guarded by `prev_status != "daily_halt"` check (same pattern as drawdown CBs).
+
+**Reset:** `reset_daily()` already clears `DAILY_PNL`. Add: if `system_status == "daily_halt"`, reset to `"active"`. This runs at market open via cron.
+
+**Executor validation:** `validate_order()` already checks `system_status == "halted"` to block all orders. Add `"daily_halt"` to the buy-only block:
+
+```python
+if order["side"] == "buy":
+    status = r.get(Keys.SYSTEM_STATUS)
+    if status in ("halted", "daily_halt"):
+        return False, f"System {status}: no new entries"
+    # existing daily_pnl check removed from here
+```
+
+### Redis State
+
+| State | Meaning | Set by | Cleared by |
+|---|---|---|---|
+| `daily_halt` | Daily loss limit hit; exits allowed, entries blocked | Supervisor CB | `reset_daily()` at market open |
+
+### Testing
+
+- Unit test: daily P&L crosses limit → `daily_halt` set, critical alert fired
+- Unit test: already `daily_halt` → no duplicate alert
+- Unit test: `reset_daily()` with `daily_halt` status → resets to `active`
+- Unit test: buy order with `daily_halt` status → rejected
+- Unit test: sell order with `daily_halt` status → **allowed through** (key correctness test)
+- Unit test: buy order with `halted` status → still rejected (existing CB unaffected)
+- Unit test: daily P&L above limit → no action
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `skills/executor/executor.py` | Add `_check_cancelled_stops()`, call in daemon loop, move daily loss check into buy-only branch, add `daily_halt` to buy rejection |
+| `skills/supervisor/supervisor.py` | Add daily loss CB to `run_circuit_breakers()`, clear `daily_halt` in `reset_daily()` |
+| `scripts/config.py` | Verify `DAILY_LOSS_LIMIT_PCT` and `Keys.DAILY_PNL` exist (likely no changes needed) |
+| `skills/executor/tests/test_executor.py` | New tests for `_check_cancelled_stops` |
+| `skills/executor/tests/test_executor_validation.py` | Tests for `daily_halt` buy/sell behaviour |
+| `skills/supervisor/tests/test_supervisor.py` | Tests for daily loss CB and reset |
+
+---
+
+## Out of Scope
+
+- Dashboard changes for `daily_halt` status (separate task)
+- Configurable resubmit retry count (YAGNI — one resubmit attempt is sufficient)
+- Alerting on the number of times a stop was cancelled (noise)

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -122,10 +122,10 @@ def _reconcile_stop_filled(r, pos, positions, symbol):
 def validate_order(r, order, account):
     """Validate order against all safety rules. Returns (ok, reason)."""
 
-    # System status
+    # System status — blocks new entries, always allows exits
     status = r.get(Keys.SYSTEM_STATUS)
-    if status == "halted" and order["side"] == "buy":
-        return False, "System is halted — no new entries"
+    if status in ("halted", "daily_halt") and order["side"] == "buy":
+        return False, f"System is {status} — no new entries"
 
     # Rule 1: Never exceed simulated cash
     if order["side"] == "buy":
@@ -134,19 +134,20 @@ def validate_order(r, order, account):
         if order_value > sim_cash:
             return False, f"Rule 1: Order ${order_value:.0f} > simulated cash ${sim_cash:.0f}"
 
+        # Daily loss limit belt-and-suspenders (supervisor sets daily_halt; this catches
+        # the gap between supervisor cron cycles). Skipped for forced orders.
+        if not order.get("force"):
+            daily_pnl = float(r.get(Keys.DAILY_PNL) or 0)
+            equity = get_simulated_equity(r)
+            if daily_pnl <= -(equity * config.DAILY_LOSS_LIMIT_PCT):
+                return False, f"Daily loss limit: ${daily_pnl:.2f}"
+
     # Rule 1: Never short
     if order["side"] == "sell":
         positions = json.loads(r.get(Keys.POSITIONS) or "{}")
         has_pos = any(p["symbol"] == order["symbol"] for p in positions.values())
         if not has_pos:
             return False, "Rule 1: Short selling prohibited"
-
-    # Daily loss limit (skipped for forced orders, e.g. manual dashboard liquidations)
-    if not order.get("force"):
-        daily_pnl = float(r.get(Keys.DAILY_PNL) or 0)
-        equity = get_simulated_equity(r)
-        if daily_pnl <= -(equity * config.DAILY_LOSS_LIMIT_PCT):
-            return False, f"Daily loss limit: ${daily_pnl:.2f}"
 
     # Max concurrent positions (for buys)
     if order["side"] == "buy":

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -757,6 +757,7 @@ def daemon_loop():  # pragma: no cover
         r.set(Keys.heartbeat("executor"), datetime.now().isoformat())
         msg = pubsub.get_message(timeout=60)
         if msg is None or msg['type'] != 'message':
+            _check_cancelled_stops(trading_client, r)
             continue
 
         try:

--- a/skills/executor/executor.py
+++ b/skills/executor/executor.py
@@ -117,6 +117,88 @@ def _reconcile_stop_filled(r, pos, positions, symbol):
     return True
 
 
+# ── Runtime Stop Monitoring ──────────────────────────────────
+
+def _check_cancelled_stops(trading_client, r):
+    """Check all open positions for unexpectedly cancelled stop orders.
+
+    Called each idle daemon cycle. For each position with a stop_order_id:
+    - 'cancelled': verify position still on Alpaca, resubmit stop, alert
+    - 'filled':    delegate to _reconcile_stop_filled
+    - healthy:     skip
+    """
+    positions = json.loads(r.get(Keys.POSITIONS) or "{}")
+    if not positions:
+        return
+
+    # Fetch Alpaca positions once for the whole check
+    try:
+        alpaca_symbols = {p.symbol for p in trading_client.get_all_positions()}
+    except Exception as exc:
+        print(f"  [Executor] _check_cancelled_stops: could not fetch Alpaca positions: {exc}")
+        return
+
+    stop_filled_syms = []
+
+    for symbol, pos in list(positions.items()):
+        stop_id = pos.get("stop_order_id")
+        if not stop_id:
+            continue
+
+        try:
+            stop_order = trading_client.get_order_by_id(stop_id)
+        except Exception as exc:
+            print(f"  [Executor] _check_cancelled_stops: could not fetch stop {stop_id} for {symbol}: {exc}")
+            continue
+
+        if stop_order.status in ("new", "accepted", "pending_new"):
+            continue  # healthy
+
+        if stop_order.status == "filled":
+            stop_filled_syms.append(symbol)
+            continue
+
+        if stop_order.status == "cancelled":
+            if symbol not in alpaca_symbols:
+                # Position was closed externally — reconcile Redis
+                print(f"  [Executor] ⚠️  {symbol}: stop cancelled + position gone — cleaning Redis")
+                critical_alert(
+                    f"STOP CANCELLED — POSITION CLOSED EXTERNALLY: {symbol}\n"
+                    f"Stop {stop_id} was cancelled and position is gone from Alpaca.\n"
+                    f"Redis cleaned up. Review P&L manually."
+                )
+                positions.pop(symbol, None)
+                r.set(Keys.POSITIONS, json.dumps(positions))
+                continue
+
+            # Position still exists — resubmit stop
+            print(f"  [Executor] ⚠️  {symbol}: stop {stop_id} cancelled — resubmitting")
+            new_stop_id = submit_stop_loss(
+                trading_client, symbol, pos["quantity"], pos["stop_price"]
+            )
+            if new_stop_id is None:
+                # submit_stop_loss already fired a critical_alert; escalate with naked position warning
+                critical_alert(
+                    f"STOP RESUBMIT FAILED — NAKED POSITION: {symbol}\n"
+                    f"Stop {stop_id} cancelled. Resubmit failed (see previous alert).\n"
+                    f"Manual intervention required immediately."
+                )
+                print(f"  [Executor] ❌ {symbol}: stop resubmit FAILED — naked position")
+            else:
+                pos["stop_order_id"] = new_stop_id
+                r.set(Keys.POSITIONS, json.dumps(positions))
+                critical_alert(
+                    f"STOP CANCELLED & RESUBMITTED: {symbol}\n"
+                    f"Old stop {stop_id} was cancelled unexpectedly.\n"
+                    f"New stop {new_stop_id} placed @ ${pos['stop_price']:.2f}."
+                )
+                print(f"  [Executor] ✅ {symbol}: new stop {new_stop_id} placed @ ${pos['stop_price']:.2f}")
+
+    # Reconcile any Alpaca-triggered stop fills found during check
+    for sym in stop_filled_syms:
+        _reconcile_stop_filled(r, positions[sym], positions, sym)
+
+
 # ── Safety Validation ───────────────────────────────────────
 
 def validate_order(r, order, account):

--- a/skills/executor/test_executor.py
+++ b/skills/executor/test_executor.py
@@ -188,6 +188,31 @@ class TestValidateOrder:
         ok, _ = validate_order(r, order, make_account())
         assert ok
 
+    def test_daily_halt_blocks_buy(self):
+        from executor import validate_order
+        r = self._r(status="daily_halt")
+        order = {"side": "buy", "quantity": 1, "entry_price": 10.0, "order_value": 10.0}
+        ok, reason = validate_order(r, order, make_account())
+        assert not ok
+        assert "daily_halt" in reason
+
+    def test_daily_halt_allows_sell(self):
+        from executor import validate_order
+        pos = make_position()
+        r = self._r(positions={"SPY": pos}, status="daily_halt")
+        order = {"side": "sell", "symbol": "SPY"}
+        ok, _ = validate_order(r, order, make_account())
+        assert ok
+
+    def test_daily_loss_limit_allows_sell(self):
+        from executor import validate_order
+        # equity=5000, DAILY_LOSS_LIMIT_PCT=0.03 → threshold=-150; pnl=-200 (breached)
+        pos = make_position()
+        r = self._r(positions={"SPY": pos}, daily_pnl="-200.0")
+        order = {"side": "sell", "symbol": "SPY"}
+        ok, _ = validate_order(r, order, make_account())
+        assert ok
+
     def test_max_positions_blocks(self):
         from executor import validate_order
         import config as cfg

--- a/skills/executor/test_executor.py
+++ b/skills/executor/test_executor.py
@@ -1129,3 +1129,158 @@ class TestProcessOrder:
         from executor import process_order
         result = process_order(r, tc, {"side": "hold", "symbol": "SPY", "quantity": 1, "entry_price": 10.0, "order_value": 10.0})
         assert result is False
+
+
+# ── TestCheckCancelledStops ──────────────────────────────────
+
+class TestCheckCancelledStops:
+    def _make_stop_order(self, status="new", stop_id="stop-456"):
+        o = MagicMock()
+        o.id = stop_id
+        o.status = status
+        return o
+
+    def _make_alpaca_position(self, symbol="SPY"):
+        p = MagicMock()
+        p.symbol = symbol
+        return p
+
+    def test_cancelled_stop_position_exists_resubmits_and_alerts(self):
+        """Cancelled stop + position on Alpaca → resubmit + critical_alert."""
+        pos = make_position(symbol="SPY", qty=10, stop=490.0, stop_order_id="old-stop")
+        r, store = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = self._make_stop_order(status="cancelled")
+        tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+        new_stop = MagicMock()
+        new_stop.id = "new-stop-999"
+        tc.submit_order.return_value = new_stop
+
+        with patch("executor.critical_alert") as mock_alert:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        # Stop resubmitted
+        tc.submit_order.assert_called_once()
+
+        # Redis updated with new stop_order_id
+        saved = json.loads(store["trading:positions"])
+        assert saved["SPY"]["stop_order_id"] == "new-stop-999"
+
+        # Alert fired
+        mock_alert.assert_called_once()
+        assert "SPY" in mock_alert.call_args[0][0]
+        assert "RESUBMIT" in mock_alert.call_args[0][0].upper()
+
+    def test_cancelled_stop_position_gone_cleans_redis_and_alerts(self):
+        """Cancelled stop + position gone from Alpaca → clean Redis + critical_alert."""
+        pos = make_position(symbol="SPY", stop_order_id="old-stop")
+        r, store = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = self._make_stop_order(status="cancelled")
+        tc.get_all_positions.return_value = []  # SPY not on Alpaca
+
+        with patch("executor.critical_alert") as mock_alert, \
+             patch("executor.submit_stop_loss") as mock_submit:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        # No stop resubmitted
+        mock_submit.assert_not_called()
+
+        # Position removed from Redis
+        saved = json.loads(store["trading:positions"])
+        assert "SPY" not in saved
+
+        # Alert fired
+        mock_alert.assert_called_once()
+        assert "SPY" in mock_alert.call_args[0][0]
+
+    def test_cancelled_stop_resubmit_fails_fires_naked_position_alert(self):
+        """Cancelled stop + resubmit returns None → NAKED POSITION alert, no Redis change.
+
+        submit_stop_loss catches exceptions internally and fires its own critical_alert,
+        then returns None. _check_cancelled_stops fires a second critical_alert escalating
+        to NAKED POSITION. Two alerts total; at least one must contain 'NAKED'.
+        """
+        pos = make_position(symbol="SPY", stop_order_id="old-stop")
+        r, store = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = self._make_stop_order(status="cancelled")
+        tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+        tc.submit_order.side_effect = RuntimeError("API timeout")
+
+        with patch("executor.critical_alert") as mock_alert:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        # At least one alert contains "NAKED"
+        assert mock_alert.called
+        assert any("NAKED" in call.args[0] for call in mock_alert.call_args_list)
+
+        # Redis not changed (stop_order_id unchanged)
+        saved = json.loads(store["trading:positions"])
+        assert saved["SPY"]["stop_order_id"] == "old-stop"
+
+    def test_filled_stop_delegates_to_reconcile(self):
+        """Stop already filled by Alpaca → delegates to _reconcile_stop_filled."""
+        pos = make_position(symbol="SPY", stop_order_id="stop-456")
+        r, store = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = self._make_stop_order(status="filled")
+        tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+
+        with patch("executor._reconcile_stop_filled") as mock_reconcile, \
+             patch("executor.critical_alert") as mock_alert:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        mock_reconcile.assert_called_once()
+        mock_alert.assert_not_called()
+
+    def test_healthy_stop_no_action(self):
+        """Stop status 'new' → no resubmit, no alert."""
+        pos = make_position(symbol="SPY", stop_order_id="stop-456")
+        r, _ = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_order_by_id.return_value = self._make_stop_order(status="new")
+        tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+
+        with patch("executor.critical_alert") as mock_alert, \
+             patch("executor.submit_stop_loss") as mock_submit:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        mock_submit.assert_not_called()
+        mock_alert.assert_not_called()
+
+    def test_no_positions_returns_early(self):
+        """No open positions → no Alpaca calls at all."""
+        r, _ = make_redis({})
+        tc = MagicMock()
+
+        from executor import _check_cancelled_stops
+        _check_cancelled_stops(tc, r)
+
+        tc.get_all_positions.assert_not_called()
+        tc.get_order_by_id.assert_not_called()
+
+    def test_no_stop_order_id_skipped(self):
+        """Position with no stop_order_id → skipped, no API calls."""
+        pos = make_position(symbol="SPY", stop_order_id=None)
+        r, _ = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_all_positions.return_value = [self._make_alpaca_position("SPY")]
+
+        with patch("executor.critical_alert") as mock_alert:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        tc.get_order_by_id.assert_not_called()
+        mock_alert.assert_not_called()

--- a/skills/executor/test_executor.py
+++ b/skills/executor/test_executor.py
@@ -1284,3 +1284,42 @@ class TestCheckCancelledStops:
 
         tc.get_order_by_id.assert_not_called()
         mock_alert.assert_not_called()
+
+    def test_get_all_positions_api_error_returns_early(self):
+        """API error fetching Alpaca positions → returns early, no per-stop checks."""
+        pos = make_position(symbol="SPY", stop_order_id="stop-456")
+        r, _ = make_redis({"SPY": pos})
+
+        tc = MagicMock()
+        tc.get_all_positions.side_effect = RuntimeError("network error")
+
+        from executor import _check_cancelled_stops
+        _check_cancelled_stops(tc, r)
+
+        tc.get_order_by_id.assert_not_called()
+
+    def test_get_order_by_id_api_error_skips_symbol(self):
+        """API error fetching a specific stop order → skips that symbol, continues loop."""
+        pos_spy = make_position(symbol="SPY", stop_order_id="stop-spy")
+        pos_qqq = make_position(symbol="QQQ", stop_order_id="stop-qqq")
+        r, store = make_redis({"SPY": pos_spy, "QQQ": pos_qqq})
+
+        tc = MagicMock()
+        tc.get_all_positions.return_value = [
+            self._make_alpaca_position("SPY"),
+            self._make_alpaca_position("QQQ"),
+        ]
+        # SPY stop fetch fails, QQQ is healthy
+        def _stop_side_effect(stop_id):
+            if stop_id == "stop-spy":
+                raise RuntimeError("order not found")
+            return self._make_stop_order(status="new", stop_id=stop_id)
+        tc.get_order_by_id.side_effect = _stop_side_effect
+
+        with patch("executor.critical_alert") as mock_alert:
+            from executor import _check_cancelled_stops
+            _check_cancelled_stops(tc, r)
+
+        # QQQ was still checked (2 calls attempted)
+        assert tc.get_order_by_id.call_count == 2
+        mock_alert.assert_not_called()

--- a/skills/supervisor/supervisor.py
+++ b/skills/supervisor/supervisor.py
@@ -103,9 +103,11 @@ def run_circuit_breakers(r):
     if daily_pnl <= -(equity * config.DAILY_LOSS_LIMIT_PCT):
         if prev_status != "daily_halt":
             r.set(Keys.SYSTEM_STATUS, "daily_halt")
-            drawdown_alert(
-                abs(daily_pnl / equity * 100),
-                f"Daily loss limit hit: ${daily_pnl:.2f}. Halted until next session."
+            critical_alert(
+                f"DAILY LOSS LIMIT HIT\n"
+                f"Today's P&L: ${daily_pnl:,.2f} "
+                f"(limit: {config.DAILY_LOSS_LIMIT_PCT * 100:.0f}% of equity)\n"
+                f"New entries halted until market open. Exits allowed."
             )
         return False
 

--- a/skills/supervisor/test_supervisor.py
+++ b/skills/supervisor/test_supervisor.py
@@ -293,10 +293,31 @@ class TestRunCircuitBreakers:
         equity = 5000.0
         daily_pnl = -(equity * _config.DAILY_LOSS_LIMIT_PCT) - 1
         r = _make_cb(equity=equity, daily_pnl=daily_pnl, status="active")
-        with patch("supervisor.drawdown_alert"):
+        with patch("supervisor.critical_alert"):
             from supervisor import run_circuit_breakers
             result = run_circuit_breakers(r)
         assert result is False
+        r.set.assert_any_call(Keys.SYSTEM_STATUS, "daily_halt")
+
+    def test_daily_loss_limit_fires_critical_alert(self):
+        equity = 5000.0
+        daily_pnl = -(equity * _config.DAILY_LOSS_LIMIT_PCT) - 1
+        r = _make_cb(equity=equity, daily_pnl=daily_pnl, status="active")
+        with patch("supervisor.critical_alert") as mock_alert:
+            from supervisor import run_circuit_breakers
+            run_circuit_breakers(r)
+        mock_alert.assert_called_once()
+        msg = mock_alert.call_args[0][0]
+        assert "DAILY LOSS" in msg
+
+    def test_daily_loss_limit_no_repeat_alert(self):
+        equity = 5000.0
+        daily_pnl = -(equity * _config.DAILY_LOSS_LIMIT_PCT) - 1
+        r = _make_cb(equity=equity, daily_pnl=daily_pnl, status="daily_halt")
+        with patch("supervisor.critical_alert") as mock_alert:
+            from supervisor import run_circuit_breakers
+            run_circuit_breakers(r)
+        mock_alert.assert_not_called()
 
 
 # ── disable_tiers / enable_all_tiers ─────────────────────────


### PR DESCRIPTION
## Summary

- **`_check_cancelled_stops`** — executor checks all open position stop orders each idle daemon cycle; if a GTC stop is unexpectedly `cancelled`, resubmits at original stop price, updates Redis, fires `critical_alert`; if position is also gone from Alpaca, cleans Redis and alerts instead
- **Daily loss CB → `critical_alert`** — supervisor's daily loss limit block was using `drawdown_alert` (soft); changed to `critical_alert` so it's as loud as the drawdown halt
- **Sell-through fix** — executor's `validate_order` was blocking both buys AND sells when daily P&L was breached; daily loss check moved inside buy-only branch; `daily_halt` status now also blocks buys but allows exits through

## Test Plan

- [ ] `PYTHONPATH=scripts python3 -m pytest skills/executor/test_executor.py --cov=executor --cov-report=term-missing` → 100%
- [ ] `PYTHONPATH=scripts python3 -m pytest skills/supervisor/test_supervisor.py --cov=supervisor --cov-report=term-missing` → 100%
- [ ] Confirm `test_daily_halt_allows_sell` and `test_daily_loss_limit_allows_sell` pass (the key sell-through regression tests)
- [ ] Confirm `test_daily_loss_limit_fires_critical_alert` passes (not drawdown_alert)
- [ ] Confirm `TestCheckCancelledStops` — 9 cases covering all paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)