### PR TITLE
fix: add missing exit_reason column to trades

### DIFF
--- a/dashboard/priv/repo/migrations/20260414000002_add_exit_reason_to_trades.exs
+++ b/dashboard/priv/repo/migrations/20260414000002_add_exit_reason_to_trades.exs
@@ -1,0 +1,11 @@
+defmodule Dashboard.Repo.Migrations.AddExitReasonToTrades do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE trades ADD COLUMN IF NOT EXISTS exit_reason TEXT"
+  end
+
+  def down do
+    execute "ALTER TABLE trades DROP COLUMN IF EXISTS exit_reason"
+  end
+end


### PR DESCRIPTION
## Summary
- Adds Ecto migration `20260414000002` to add `exit_reason TEXT` to the `trades` table
- Uses `IF NOT EXISTS` / `IF EXISTS` — safe on both production (column missing) and fresh installs (column already there from migration 1)

## Why
The executor's `_log_trade` has been silently failing with `column "exit_reason" of relation "trades" does not exist` since the column was added to the schema but the ALTER TABLE init-db script never ran on the existing volume. All three trades executed today were lost to this silent failure.

After merge + deploy, `Dashboard.Release.migrate()` runs automatically on container start and adds the column. Trade logging resumes immediately.

## Test plan
- [ ] Merge PR #105 first (already done)
- [ ] Merge this PR
- [ ] `docker compose up --build -d dashboard` on VPS
- [ ] Confirm dashboard logs show migration 20260414000002 applied
- [ ] Confirm trades page shows data after next executor run

🤖 Generated with [Claude Code](https://claude.com/claude-code)