### PR TITLE
fix: use relative path for logs volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       timescaledb:
         condition: service_healthy
     volumes:
-      - ${HOME}/trading-system/logs:/app/logs:ro
+      - ./logs:/app/logs:ro
       - /var/log:/var/log/host:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4000/health"]


### PR DESCRIPTION
## Summary
- Changes `${HOME}/trading-system/logs:/app/logs:ro` → `./logs:/app/logs:ro` in docker-compose.yml

## Root cause
`HOME` is not in `~/trading-system/.env` (generated only from `~/.trading_env`). Docker Compose substituted it as empty string, making the host path `/trading-system/logs`. Docker created that as a fresh root-owned directory and mounted it empty into the container. `LogTailer` polled `/app/logs/` and found nothing — silently skipping all sources.

The relative path `./logs` is always resolved relative to `docker-compose.yml`, which lives at `~/trading-system/`, so it correctly maps to `~/trading-system/logs/` without needing any env variable.

## Test plan
- [ ] Merge this PR
- [ ] `docker compose up -d dashboard` on VPS (recreates container with corrected mount)
- [ ] `docker exec trading_dashboard ls /app/logs/` — should show agent and docker log files
- [ ] Open dashboard Logs page, toggle a source, confirm lines appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)