### PR TITLE
fix: configure Tzdata.TimeZoneDatabase in config.exs

### DIFF
--- a/dashboard/config/config.exs
+++ b/dashboard/config/config.exs
@@ -20,6 +20,8 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
+config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
+
 config :phoenix, :json_library, Jason
 
 config :esbuild,


### PR DESCRIPTION
## Summary
- `tzdata` was only configured as the timezone database in `test.exs`, not `config.exs`
- `DateTime.shift_zone/2` in `Dashboard.ScreenerStatus` (added in #148) crashed prod with `{:error, :utc_only_time_zone_database}`, breaking the dashboard
- One-line fix: add `config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase` to `config.exs`

## Test plan
- [ ] `mix test` — 442 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)