### PR TITLE
fix: PM displacement re-displaces when vacating symbol still in Redis (v0.35.4)

### DIFF
--- a/.remember/remember.md
+++ b/.remember/remember.md
@@ -1,12 +1,14 @@
 # Handoff
 
 ## State
-Two merged PRs (#158, #159). One open PR:
-- PR #160 (pending) on `fix/watchlist-panel-full-width` (v0.35.3): watchlist panel moved to full-width below two-column grid; internal two-column item layout preserved at lg+.
+PR #160 merged (v0.35.3). New fix on `fix/watchlist-panel-full-width` branch (stale name):
+- Bug: AG displaced for XLI, XLI never bought — PM drains displacement_pending synchronously before executor removes AG from Redis, re-eval sees MAX positions and re-displaces to a second victim
+- Fix: drain tags pending signal with `_displaced_symbol`; evaluate_entry_signal subtracts 1 from concurrent + asset class counts for the vacating slot; counts derived from already-loaded existing_positions (no extra Redis reads)
+- 960 tests passing
 
 ## Next
-- Merge PR #160 once CI passes
-- After merge: tag v0.35.3
+- cpr this fix (create new branch first — current branch is stale name)
+- Tag v0.35.4 after merge
 - Redis WRONGTYPE error in verify_alpaca.py is a separate unresolved issue
 
 ## Context

--- a/skills/portfolio_manager/portfolio_manager.py
+++ b/skills/portfolio_manager/portfolio_manager.py
@@ -171,8 +171,18 @@ def evaluate_entry_signal(r, signal):
     if symbol in disabled:
         return None, f"{symbol} is currently disabled"
 
+    # When re-evaluating a pending entry after a displacement exit was approved,
+    # the displaced symbol is still in Redis (executor hasn't filled yet) but its
+    # slot is already spoken for — subtract 1 from the relevant limit checks.
+    _vacating = signal.get("_displaced_symbol")
+    _vacating_in_redis = _vacating is not None and _vacating in existing_positions
+    _vacating_is_crypto = _vacating_in_redis and is_crypto(_vacating)
+
     # ── Position limits (sell-to-make-room) ──
-    num_positions = count_open_positions(r)
+    # Derive counts from already-loaded existing_positions to avoid extra Redis reads.
+    _crypto_count = sum(1 for p in existing_positions.values() if is_crypto(p["symbol"]))
+    _equity_count = len(existing_positions) - _crypto_count
+    num_positions = len(existing_positions) - int(_vacating_in_redis)
     if num_positions >= config.MAX_CONCURRENT_POSITIONS:
         # Score gate: only displace for sufficiently strong incoming signals
         incoming_score = signal.get("signal_score", 0)
@@ -221,9 +231,9 @@ def evaluate_entry_signal(r, signal):
         return None, f"Displacement queued — {target_pos['symbol']} closing for {symbol}"
 
     # Asset class limits
-    if is_crypto(symbol) and count_crypto_positions(r) >= config.MAX_CRYPTO_POSITIONS:
+    if is_crypto(symbol) and _crypto_count - int(_vacating_is_crypto) >= config.MAX_CRYPTO_POSITIONS:
         return None, "Max crypto positions reached"
-    if not is_crypto(symbol) and count_equity_positions(r) >= config.MAX_EQUITY_POSITIONS:
+    if not is_crypto(symbol) and _equity_count - int(_vacating_in_redis and not _vacating_is_crypto) >= config.MAX_EQUITY_POSITIONS:
         return None, "Max equity positions reached"
 
     # ── Sector correlation ──
@@ -393,7 +403,9 @@ def process_signal(r, signal):
             while r.llen(pending_key):
                 raw = r.lpop(pending_key)
                 if raw:
-                    process_signal(r, json.loads(raw))
+                    pending_signal = json.loads(raw)
+                    pending_signal["_displaced_symbol"] = symbol
+                    process_signal(r, pending_signal)
             return order
         else:
             print(f"  ⚠️  [PM] EXIT BLOCKED: {symbol} — {rejection}")

--- a/skills/portfolio_manager/test_portfolio_manager.py
+++ b/skills/portfolio_manager/test_portfolio_manager.py
@@ -801,3 +801,48 @@ class TestDisplacementPendingQueue:
         process_signal(r, displaced_signal)
 
         r.llen.assert_not_called()
+
+    def test_pending_entry_not_re_displaced_when_vacating_symbol_still_in_positions(self):
+        """
+        Bug: when the drain re-processes XLI after AG's exit is approved, AG is
+        still in trading:positions (executor hasn't filled yet).  evaluate_entry_signal
+        sees MAX positions → triggers another displacement → XLI never bought.
+        Fix: _displaced_symbol on the re-processed signal causes evaluate_entry_signal
+        to subtract 1 for the slot being vacated (both concurrent and asset-class checks),
+        so XLI is approved directly.
+
+        Realistic setup: 3 equity (SPY, QQQ, AG) + 2 crypto = 5 = MAX_CONCURRENT.
+        AG (equity) is displaced for XLI (equity).
+        """
+        positions = {
+            "SPY": _pos("SPY", pnl_pct=1.0, held_days=2),
+            "QQQ": _pos("QQQ", pnl_pct=1.0, held_days=2),
+            "AG": _pos("AG", pnl_pct=-1.61, held_days=2),
+            "BTC/USD": _pos("BTC/USD", pnl_pct=0.5, held_days=2),
+            "ETH/USD": _pos("ETH/USD", pnl_pct=0.3, held_days=2),
+        }
+        xli_signal = make_signal(symbol="XLI", tier=1, signal_type="entry")
+        r = make_redis({
+            Keys.POSITIONS: json.dumps(positions),
+            Keys.SIMULATED_EQUITY: "10000.0",
+            Keys.PEAK_EQUITY: "10000.0",
+        })
+        r.llen = MagicMock(side_effect=[1, 0])
+        r.lpop = MagicMock(return_value=json.dumps(xli_signal))
+
+        displaced_signal = {
+            "symbol": "AG",
+            "signal_type": "displaced",
+            "reason": "Displaced to make room for XLI",
+            "direction": "close",
+            "exit_price": 20.80,
+        }
+        from portfolio_manager import process_signal
+        process_signal(r, displaced_signal)
+
+        approved = {
+            json.loads(c[0][1])["symbol"]
+            for c in r.publish.call_args_list
+            if c[0][0] == Keys.APPROVED_ORDERS
+        }
+        assert "XLI" in approved, f"XLI was not approved — published to APPROVED_ORDERS: {approved}"


### PR DESCRIPTION
## Summary

- **Root cause**: when `evaluate_entry_signal` re-processes a pending entry (XLI) after approving a displacement exit (AG), AG is still in `trading:positions` because the executor fills asynchronously. The position count was at MAX, so XLI triggered another displacement of an unrelated position and was never approved.
- **Fix**: drain tags each pending signal with `_displaced_symbol`; `evaluate_entry_signal` subtracts 1 from the concurrent and asset-class position counts for the slot being vacated.
- **Efficiency**: counts now derived from `existing_positions` (already loaded at top of function) — eliminates 3 extra Redis reads per evaluation.

## Test plan

- [ ] New test: `test_pending_entry_not_re_displaced_when_vacating_symbol_still_in_positions` — 5 positions at MAX (3 equity + 2 crypto), AG displaced for XLI, asserts XLI is approved to APPROVED_ORDERS in the same drain cycle
- [ ] 960 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)